### PR TITLE
[Feat] 카테고리 생성 및 수정 뷰 구현 및 재사용 가능한 컴포넌트 구현

### DIFF
--- a/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
+++ b/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -304,6 +305,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/CameraView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/CameraView.swift
@@ -1,0 +1,43 @@
+//
+//  CameraView.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/9/25.
+//
+
+import SwiftUI
+
+struct CameraView: UIViewControllerRepresentable {
+    @Binding var selectedImage: UIImage?
+    @Environment(\.presentationMode) var isPresented
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        imagePicker.sourceType = .camera
+        imagePicker.allowsEditing = true
+        imagePicker.delegate = context.coordinator
+        return imagePicker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(picker: self)
+    }
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var picker: CameraView
+
+        init(picker: CameraView) {
+            self.picker = picker
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            guard let selectedImage = info[.originalImage] as? UIImage else { return }
+            self.picker.selectedImage = selectedImage
+            self.picker.isPresented.wrappedValue.dismiss()
+        }
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoButtonStyle.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoButtonStyle.swift
@@ -1,0 +1,28 @@
+//
+//  StaccatoButtonStyle.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/8/25.
+//
+
+import SwiftUI
+
+struct StaccatoFullWidthButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundStyle(isEnabled ? .white : .gray4)
+            .typography(.title3)
+            .background {
+                RoundedRectangle(cornerRadius: 5)
+                    .foregroundStyle(
+                        isEnabled ?
+                        (configuration.isPressed ? .accent.opacity(0.7) : .accent)
+                        : .gray1
+                    )
+            }
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoNavigationBar.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoNavigationBar.swift
@@ -1,0 +1,110 @@
+//
+//  StaccatoNavigationBar.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/9/25.
+//
+
+import SwiftUI
+
+struct StaccatoNavigationBar<T: View>: ViewModifier {
+    @Environment(\.dismiss) var dismiss
+
+    let title: String?
+    let subtitle: String?
+    let trailingButtons: T
+
+    init(title: String?, subtitle: String?, @ViewBuilder trailingButtons: () -> T) {
+        self.title = title
+        self.subtitle = subtitle
+        self.trailingButtons = trailingButtons()
+    }
+
+    func body(content: Content) -> some View {
+        VStack {
+            ZStack {
+                HStack(spacing: 16) {
+                    Button  {
+                        dismiss()
+                    } label: {
+                        Image(systemName: StaccatoIcon.chevronLeft.rawValue)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 20)
+                            .padding(.leading, 16)
+                            .foregroundStyle(.gray2)
+                    }
+
+                    VStack(alignment: .leading) {
+                        if let title {
+                            Text(title)
+                                .typography(.title2)
+                                .foregroundStyle(.gray5)
+                        }
+
+                        if let subtitle {
+                            Text(subtitle)
+                                .typography(.body4)
+                                .foregroundStyle(.gray5)
+                        }
+                    }
+
+                    Spacer()
+
+                    // 여기에 오른쪽 요소들
+                    HStack(spacing: 16) {
+                        trailingButtons
+                    }
+                    .padding(.trailing, 10)
+                    .typography(.body2)
+                    .foregroundStyle(.gray5)
+                }
+
+            }
+            .frame(height: 56)
+
+            Spacer()
+
+            content
+
+            Spacer()
+        }
+        .toolbarVisibility(.hidden, for: .navigationBar)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        NavigationLink {
+            VStack {
+                Text("컨텐츠")
+                Text("컨텐츠")
+                Text("컨텐츠")
+                Text("컨텐츠")
+                Text("컨텐츠")
+            }
+            .staccatoNavigationBar(title: "카테고리 만들기", subtitle: "스타카토를 담을 카테고리를 만들어 보세요!")
+        } label: {
+            Text("NavigationTest : 다음 화면으로 이동")
+        }
+    }
+}
+
+extension View {
+    func staccatoNavigationBar<T: View>(
+        title: String? = nil,
+        subtitle: String? = nil,
+        @ViewBuilder trailingButtons: () -> T
+    ) -> some View {
+        self
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, trailingButtons: trailingButtons))
+    }
+
+    func staccatoNavigationBar(
+        title: String? = nil,
+        subtitle: String? = nil
+    ) -> some View {
+        self
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, trailingButtons: { }))
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextEditorStyle.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextEditorStyle.swift
@@ -1,0 +1,68 @@
+//
+//  StaccatoTextEditorStyle.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/8/25.
+//
+
+import SwiftUI
+
+struct StaccatoTextEditorStyle: ViewModifier {
+    @Binding var text: String
+    @FocusState<Bool>.Binding var isFocused: Bool
+
+    let placeholder: String
+    let maximumTextLength: Int
+
+    init (placeholder: String = "", text: Binding<String>, maximumTextLength: Int, isFocused: FocusState<Bool>.Binding) {
+        self.placeholder = placeholder
+        self._text = text
+        self.maximumTextLength = maximumTextLength
+        self._isFocused = isFocused
+    }
+
+    func body(content: Content) -> some View {
+        VStack {
+            content
+                .typography(.body1)
+                .foregroundStyle(.staccatoBlack)
+                .padding(12)
+                .frame(height: 100)
+                .scrollContentBackground(.hidden)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .foregroundStyle(.gray1)
+                )
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .overlay(alignment: .topLeading) {
+                    if !isFocused {
+                        Text(placeholder)
+                            .padding(12)
+                            .typography(.body1)
+                            .foregroundStyle(.gray3)
+                    }
+                }
+                .onChange(of: text) { _, newValue in
+                    if newValue.count > maximumTextLength {
+                        text = String(newValue.prefix(maximumTextLength))
+                    }
+                }
+
+
+            HStack {
+                Spacer()
+
+                Text("\(text.count)/\(maximumTextLength)")
+                    .typography(.body3)
+                    .foregroundStyle(.gray3)
+            }
+        }
+    }
+}
+
+extension TextEditor {
+    func staccatoTextEditorStyle(placeholder: String, text: Binding<String>, maximumTextLength: Int, isFocused: FocusState<Bool>.Binding) -> some View {
+        self.modifier(StaccatoTextEditorStyle(placeholder: placeholder, text: text, maximumTextLength: maximumTextLength, isFocused: isFocused))
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextEditorStyle.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextEditorStyle.swift
@@ -26,7 +26,8 @@ struct StaccatoTextEditorStyle: ViewModifier {
             content
                 .typography(.body1)
                 .foregroundStyle(.staccatoBlack)
-                .padding(12)
+                .padding(.leading, 12)
+                .padding(.top, 3)
                 .frame(height: 100)
                 .scrollContentBackground(.hidden)
                 .background(
@@ -35,8 +36,9 @@ struct StaccatoTextEditorStyle: ViewModifier {
                 )
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
+                .scrollIndicators(.hidden)
                 .overlay(alignment: .topLeading) {
-                    if !isFocused {
+                    if !isFocused && text.isEmpty {
                         Text(placeholder)
                             .padding(12)
                             .typography(.body1)

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -1,0 +1,81 @@
+//
+//  StaccatoTextField.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/7/25.
+//
+
+import SwiftUI
+
+/// # StaccatoTextField
+///
+/// Staccato iOS 앱에서 사용하는 TextField입니다. 글자수를 제한하는 기능을 제공합니다.
+///
+/// - Parameters:
+///     - text: 입력 받을 text를 바인딩합니다.
+///     - maximumTextLength: 제한 할 글자수를 지정합니다.
+///
+/// - Usage:
+/// ```swift
+/// @State private var text: String = ""
+///
+/// var body: some View {
+///     StaccatoTextField(text: $text, maximumTextLength: 30)
+/// }
+/// ```
+struct StaccatoTextField: View {
+    @Binding var text: String
+
+    let maximumTextLength: Int
+
+    var body: some View {
+        VStack {
+            TextField("카테고리 제목을 입력해주세요(최대 30자)", text: $text)
+                .textFieldStyle(StaccatoTextFieldStyle())
+                .onChange(of: text) { _, newValue in
+                    if newValue.count > maximumTextLength {
+                        text = String(newValue.prefix(maximumTextLength))
+                    }
+                }
+
+            HStack {
+                Spacer()
+
+                Text("\(text.count)/\(maximumTextLength)")
+                    .typography(.body3)
+                    .foregroundStyle(.gray3)
+            }
+        }
+    }
+}
+
+/// # StaccatoTextFieldStyle
+///
+/// Staccato iOS 앱에서 사용하는 TextField 스타일입니다.
+///
+/// - Usage:
+/// ```swift
+/// @State private var text: String = ""
+///
+/// var body: some View {
+///     TextField("텍스트필드 설명", text: $text)
+///         .textFieldStyle(StaccatoTextFieldStyle())
+/// }
+/// ```
+struct StaccatoTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<_Label>) -> some View {
+        HStack {
+            configuration
+                .typography(.body1)
+                .foregroundStyle(.staccatoBlack)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+
+            Spacer()
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .foregroundStyle(.gray1)
+        )
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -70,11 +70,13 @@ struct StaccatoTextFieldStyle: TextFieldStyle {
             configuration
                 .typography(.body1)
                 .foregroundStyle(.staccatoBlack)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
+                .padding(12)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
 
             Spacer()
         }
+        .frame(height: 45)
         .background(
             RoundedRectangle(cornerRadius: 5)
                 .foregroundStyle(.gray1)

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -26,14 +26,23 @@ import SwiftUI
 /// ```
 struct StaccatoTextField: View {
     @Binding var text: String
+    @FocusState<Bool>.Binding var isFocused: Bool
 
     let placeholder: String
     let maximumTextLength: Int
 
     var body: some View {
         VStack {
-            TextField(placeholder, text: $text)
+            TextField("", text: $text)
                 .textFieldStyle(StaccatoTextFieldStyle())
+                .overlay(alignment: .topLeading) {
+                    if !isFocused && text.isEmpty {
+                        Text(placeholder)
+                            .padding(12)
+                            .typography(.body1)
+                            .foregroundStyle(.gray3)
+                    }
+                }
                 .onChange(of: text) { _, newValue in
                     if newValue.count > maximumTextLength {
                         text = String(newValue.prefix(maximumTextLength))

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -13,6 +13,7 @@ import SwiftUI
 ///
 /// - Parameters:
 ///     - text: 입력 받을 text를 바인딩합니다.
+///     - placeholder: 텍스트필드의 설명을 작성합니다.
 ///     - maximumTextLength: 제한 할 글자수를 지정합니다.
 ///
 /// - Usage:
@@ -26,11 +27,12 @@ import SwiftUI
 struct StaccatoTextField: View {
     @Binding var text: String
 
+    let placeholder: String
     let maximumTextLength: Int
 
     var body: some View {
         VStack {
-            TextField("카테고리 제목을 입력해주세요(최대 30자)", text: $text)
+            TextField(placeholder, text: $text)
                 .textFieldStyle(StaccatoTextFieldStyle())
                 .onChange(of: text) { _, newValue in
                     if newValue.count > maximumTextLength {

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoToggleStyle.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoToggleStyle.swift
@@ -22,24 +22,13 @@ import SwiftUI
 /// ```
 struct StaccatoToggleStyle: ToggleStyle {
     func makeBody(configuration: Configuration) -> some View {
-        ZStack {
+        ZStack(alignment: configuration.isOn ? .trailing : .leading) {
             Capsule()
                 .foregroundStyle(configuration.isOn ? .accent : .gray4)
 
-            HStack {
-                if configuration.isOn {
-                    Spacer()
-                }
-
-                Circle()
-                    .foregroundStyle(.white)
-                    .padding(2)
-
-                if !configuration.isOn {
-                    Spacer()
-                }
-            }
-
+            Circle()
+                .foregroundStyle(.white)
+                .padding(2)
         }
         .frame(width: 48, height: 20)
         .animation(.easeInOut(duration: 0.2), value: configuration.isOn)

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoToggleStyle.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoToggleStyle.swift
@@ -1,0 +1,51 @@
+//
+//  StaccatoToggleStyle.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/7/25.
+//
+
+import SwiftUI
+
+/// # StaccatoToggleStyle
+///
+/// Staccato iOS 앱에서 사용하는 Toggle 스타일입니다.
+///
+/// - Usage:
+/// ```swift
+/// @State private var isOn: Bool = false
+///
+/// var body: some View {
+///     Toggle("라벨", isOn: $isOn)
+///         .toggleStyle(StaccatoToggleStyle())
+/// }
+/// ```
+struct StaccatoToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ZStack {
+            Capsule()
+                .foregroundStyle(configuration.isOn ? .accent : .gray4)
+
+            HStack {
+                if configuration.isOn {
+                    Spacer()
+                }
+
+                Circle()
+                    .foregroundStyle(.white)
+                    .padding(2)
+
+                if !configuration.isOn {
+                    Spacer()
+                }
+            }
+
+        }
+        .frame(width: 48, height: 20)
+        .animation(.easeInOut(duration: 0.2), value: configuration.isOn)
+        .onTapGesture {
+            configuration.isOn.toggle()
+        }
+
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -8,34 +8,54 @@
 import SwiftUI
 
 struct CategoryEditorView: View {
-    @State var isPeriodSettingActive = false
-    @State var categoryTitle = ""
-    @State var categoryDescription = ""
+    @State private var categoryTitle = ""
+    @FocusState private var isTitleFocused: Bool
 
-    @State var isAble = false
+    @State private var categoryDescription = ""
+    @FocusState private var isDescriptionFocused: Bool
+
+    @State private var isPeriodSettingActive = false
+    @State var categoryPeriod: String?
+    @State private var isPeriodSheetPresented = false
+
+    private var isSubmitButtonDisabled: Bool {
+        return categoryTitle.isEmpty || (isPeriodSettingActive && categoryPeriod == nil)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            photoPlaceholder
-                .padding(.bottom, 36)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                photoPlaceholder
+                    .padding(.bottom, 36)
+                Group {
+                    titleInputSection
+                        .padding(.bottom, 24)
 
-            titleInputSection
-                .padding(.bottom, 18)
+                    descriptionInputSection
+                        .padding(.bottom, 24)
 
-            descriptionInputSection
-                .padding(.bottom, 18)
+                    periodSettingSection
+                        .padding(.bottom, 24)
+                }
+                .padding(.horizontal, 4)
 
-            periodSettingSection
-                .padding(.bottom, 18)
+                Spacer()
 
-            Spacer()
+                Button("저장") {
 
-            Button("저장") {
-                isAble.toggle()
+                }
+                .buttonStyle(StaccatoFullWidthButtonStyle())
+                .disabled(isSubmitButtonDisabled)
             }
-            .buttonStyle(StaccatoFullWidthButtonStyle())
+            .animation(.easeIn(duration: 0.15), value: isPeriodSettingActive)
         }
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 20)
+
+        .sheet(isPresented: $isPeriodSheetPresented) {
+
+        } content: {
+            
+        }
     }
 }
 
@@ -76,7 +96,13 @@ extension CategoryEditorView {
             .typography(.title2)
             .padding(.bottom, 8)
 
-            StaccatoTextField(text: $categoryTitle, placeholder: "카테고리 제목을 입력해주세요(최대 30자)", maximumTextLength: 30)
+            StaccatoTextField(
+                text: $categoryTitle,
+                isFocused: $isTitleFocused,
+                placeholder: "카테고리 제목을 입력해주세요(최대 30자)",
+                maximumTextLength: 30
+            )
+            .focused($isTitleFocused)
         }
     }
 
@@ -86,7 +112,14 @@ extension CategoryEditorView {
                 .foregroundStyle(.staccatoBlack)
                 .typography(.title2)
 
-            StaccatoTextField(text: $categoryDescription, placeholder: "카테고리 소개를 입력해주세요(최대 500자)", maximumTextLength: 500)
+            TextEditor(text: $categoryDescription)
+                .staccatoTextEditorStyle(
+                    placeholder: "카테고리 소개를 입력해주세요(최대 500자)",
+                    text: $categoryDescription,
+                    maximumTextLength: 500,
+                    isFocused: $isDescriptionFocused
+                )
+                .focused($isDescriptionFocused)
         }
     }
 
@@ -101,6 +134,27 @@ extension CategoryEditorView {
 
                 Toggle("", isOn: $isPeriodSettingActive)
                     .toggleStyle(StaccatoToggleStyle())
+            }
+
+            Text("'여행'과 같은 카테고리라면 기간을 선택할 수 있어요.")
+                .typography(.body4)
+                .foregroundStyle(.gray3)
+                .padding(.bottom, 12)
+
+            if isPeriodSettingActive {
+                Button {
+                    isPeriodSheetPresented = true
+                } label: {
+                    Text(categoryPeriod ?? "카테고리 기간을 선택해주세요")
+                        .foregroundStyle(categoryPeriod == nil ? .gray3 : .staccatoBlack)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background {
+                            RoundedRectangle(cornerRadius: 5)
+                                .foregroundStyle(.gray1)
+                        }
+                }
             }
         }
     }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -50,6 +50,8 @@ struct CategoryEditorView: View {
             .animation(.easeIn(duration: 0.15), value: isPeriodSettingActive)
         }
         .padding(.horizontal, 20)
+        .staccatoNavigationBar(title: "카테고리 만들기", subtitle: "스타카토를 담을 카테고리를 만들어 보세요!")
+        .ignoresSafeArea(.all, edges: .bottom)
 
         .sheet(isPresented: $isPeriodSheetPresented) {
 
@@ -60,7 +62,9 @@ struct CategoryEditorView: View {
 }
 
 #Preview {
-    CategoryEditorView()
+    NavigationStack {
+        CategoryEditorView()
+    }
 }
 
 extension CategoryEditorView {

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -8,17 +8,100 @@
 import SwiftUI
 
 struct CategoryEditorView: View {
-    @State var isOn = false
+    @State var isPeriodSettingActive = false
+    @State var categoryTitle = ""
+    @State var categoryDescription = ""
+
+    @State var isAble = false
 
     var body: some View {
-        Toggle("", isOn: $isOn)
-            .toggleStyle(StaccatoToggleStyle())
+        VStack(alignment: .leading, spacing: 0) {
+            photoPlaceholder
+                .padding(.bottom, 36)
 
-        Toggle("", isOn: $isOn)
+            titleInputSection
+                .padding(.bottom, 18)
 
+            descriptionInputSection
+                .padding(.bottom, 18)
+
+            periodSettingSection
+                .padding(.bottom, 18)
+
+            Spacer()
+
+            Button("저장") {
+                isAble.toggle()
+            }
+            .buttonStyle(StaccatoFullWidthButtonStyle())
+        }
+        .padding(.horizontal, 24)
     }
 }
 
 #Preview {
     CategoryEditorView()
+}
+
+extension CategoryEditorView {
+    private var photoPlaceholder: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .foregroundStyle(.gray1)
+            .overlay {
+                VStack(spacing: 0) {
+                    Image(systemName: StaccatoIcon.camera.rawValue)
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(.gray4)
+                        .frame(width: 37)
+                        .padding(.bottom, 10)
+
+                    Text("사진을 첨부해주세요")
+                        .typography(.body4)
+                        .foregroundStyle(.gray4)
+                }
+            }
+            .frame(height: 200)
+            .padding(.top, 12)
+    }
+
+    private var titleInputSection: some View {
+        VStack(alignment: .leading) {
+            Group {
+                Text("카테고리 제목 ")
+                    .foregroundStyle(.staccatoBlack)
+                + Text("*")
+                    .foregroundStyle(.accent)
+            }
+            .typography(.title2)
+            .padding(.bottom, 8)
+
+            StaccatoTextField(text: $categoryTitle, placeholder: "카테고리 제목을 입력해주세요(최대 30자)", maximumTextLength: 30)
+        }
+    }
+
+    private var descriptionInputSection: some View {
+        VStack(alignment: .leading) {
+            Text("카테고리 소개")
+                .foregroundStyle(.staccatoBlack)
+                .typography(.title2)
+
+            StaccatoTextField(text: $categoryDescription, placeholder: "카테고리 소개를 입력해주세요(최대 500자)", maximumTextLength: 500)
+        }
+    }
+
+    private var periodSettingSection: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("기간 설정")
+                    .foregroundStyle(.staccatoBlack)
+                    .typography(.title2)
+
+                Spacer()
+
+                Toggle("", isOn: $isPeriodSettingActive)
+                    .toggleStyle(StaccatoToggleStyle())
+            }
+        }
+    }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -11,9 +11,10 @@ import PhotosUI
 struct CategoryEditorView: View {
     @State private var isPhotoInputPresented = false
     @State private var isPhotoPickerPresented = false
+    @State private var showCamera = false
 
     @State private var photoItem: PhotosPickerItem?
-    @State private var selectedPhoto: Image?
+    @State private var selectedPhoto: UIImage?
 
     @State private var categoryTitle = ""
     @FocusState private var isTitleFocused: Bool
@@ -84,7 +85,7 @@ extension CategoryEditorView {
             isPhotoInputPresented = true
         } label: {
             if let selectedPhoto {
-                selectedPhoto
+                Image(uiImage: selectedPhoto)
                     .resizable()
                     .scaledToFill()
             } else {
@@ -97,16 +98,23 @@ extension CategoryEditorView {
         .onChange(of: photoItem) { _, newValue in
             loadTransferable(from: newValue)
         }
+
         .confirmationDialog("사진을 첨부해 보세요", isPresented: $isPhotoInputPresented, titleVisibility: .visible, actions: {
             Button("카메라 열기") {
-
+                showCamera = true
             }
+
             Button("앨범에서 가져오기") {
                 isPhotoPickerPresented = true
             }
         })
 
         .photosPicker(isPresented: $isPhotoPickerPresented, selection: $photoItem)
+
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraView(selectedImage: $selectedPhoto)
+                .background(.black)
+        }
     }
 
     private var photoPlaceholder: some View {
@@ -210,8 +218,8 @@ extension CategoryEditorView {
 extension CategoryEditorView {
     private func loadTransferable(from imageSelection: PhotosPickerItem?) {
         Task {
-            if let image = try? await imageSelection?.loadTransferable(type: Image.self) {
-                selectedPhoto = image
+            if let imageData = try? await imageSelection?.loadTransferable(type: Data.self) {
+                selectedPhoto = UIImage(data: imageData)
             }
         }
     }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -209,17 +209,9 @@ extension CategoryEditorView {
 // MARK: - Method
 extension CategoryEditorView {
     private func loadTransferable(from imageSelection: PhotosPickerItem?) {
-        imageSelection?.loadTransferable(type: Image.self) { result in
-            DispatchQueue.main.async {
-                guard imageSelection == self.photoItem else { return }
-                switch result {
-                case .success(let image?):
-                    selectedPhoto = image
-                case .success(nil):
-                    break
-                case .failure(_):
-                    break
-                }
+        Task {
+            if let image = try? await imageSelection?.loadTransferable(type: Image.self) {
+                selectedPhoto = image
             }
         }
     }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -64,7 +64,8 @@ struct CategoryEditorView: View {
         .sheet(isPresented: $isPeriodSheetPresented) {
 
         } content: {
-
+            // TODO: 달력 구현
+            Text("여기에 달력")
         }
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -1,0 +1,24 @@
+//
+//  CategoryEditorView.swift
+//  Staccato-iOS
+//
+//  Created by Gyunni on 1/7/25.
+//
+
+import SwiftUI
+
+struct CategoryEditorView: View {
+    @State var isOn = false
+
+    var body: some View {
+        Toggle("", isOn: $isOn)
+            .toggleStyle(StaccatoToggleStyle())
+
+        Toggle("", isOn: $isOn)
+
+    }
+}
+
+#Preview {
+    CategoryEditorView()
+}

--- a/Staccato-iOS/Staccato-iOS/Resources/Assets.xcassets/Color/Text/gray1.colorset/Contents.json
+++ b/Staccato-iOS/Staccato-iOS/Resources/Assets.xcassets/Color/Text/gray1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.957",
+          "green" : "0.957",
+          "red" : "0.957"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Staccato-iOS/Staccato-iOS/Resources/Assets.xcassets/Color/Text/gray2.colorset/Contents.json
+++ b/Staccato-iOS/Staccato-iOS/Resources/Assets.xcassets/Color/Text/gray2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.824",
+          "green" : "0.824",
+          "red" : "0.824"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Staccato-iOS/Staccato-iOS/Support/Info.plist
+++ b/Staccato-iOS/Staccato-iOS/Support/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>우리의 추억을 저장하기 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>PretendardVariable.ttf</string>


### PR DESCRIPTION
## 🔍 What is this PR?
- 카테고리 생성 및 수정할 수 있는 뷰 구현
- 기타 재사용 가능한 컴포넌트들 구현

##  💭 Related Issues
- resolved #2 

## 📝 구현 내용
### 시스템 수정 사항
- Gray1, Gray2 색상 추가
- iOS 최소 버전 변경 18.2 -> 18.0

### 컴포넌트
- Toggle Button 컴포넌트 구현
- TextField 컴포넌트 구현
- FullWidthButton 컴포넌트 구현
- TextEditor 컴포넌트 구현
- CustomNavigationBar 구현
- CameraView 구현

### 화면 구현
- CategoryEditorView 구현 : 생성 및 수정이 가능한 카테고리 뷰를 구현하였습니다.

### 기능 구현
- Camera 접근 및 사진 업로드 기능 구현
- Photo 갤러리 접근 및 사진 업로드 구현

### 📷 Screenshot 
|    CategoryEditorView    |   카메라&앨범 선택 ActivitySheet   |   앨범 접근   |
| :-------------: | :----------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/fc276d32-3e9b-4d51-bd72-19078d591306" width = "220">  | <img src = "https://github.com/user-attachments/assets/de5fd934-c172-41c2-8c46-ab9347c83105" width ="220"> | <img src = "https://github.com/user-attachments/assets/6a7ef8ff-0fcb-419c-bf4f-05d0ea4f502d" width ="220"> |

|    카메라 접근 권한    |   카메라 접근   |
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/482de641-4d6f-4e61-bca5-2ac143289d88" width = "220">  | <img src = "https://github.com/user-attachments/assets/812c3a18-b29a-4cf1-a5b8-6c6bc44e775f" width ="220"> | 

## 🙏 To Reviewers 
리뷰할 코드의 양이 조금 많을 수 있습니다. 번거롭더라도 리뷰 부탁드립니다.
자세한 구현 내용은 코드에 직접 리뷰하도록 하겠습니다.


## 📚 참고자료
카메라 접근 : https://medium.com/@jakir/access-the-camera-and-photo-library-in-swiftui-0351a3c280f5