### PR TITLE
Feat/#22 login api

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/RecoverAccountView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/RecoverAccountView.swift
@@ -27,7 +27,6 @@ struct RecoverAccountView: View {
             .padding()
             .background(.gray1)
             .cornerRadius(4)
-            .shadow(color: .gray3.opacity(0.5), radius: 10, x: 0, y: 5)
             .onChange(of: code) { _, newValue in
                 if newValue.count > 36 {
                     code = String(newValue.prefix(36))
@@ -39,20 +38,12 @@ struct RecoverAccountView: View {
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.bottom)
             Spacer()
-            Button(action: {
-                //TODO: 버튼 액션 추가해야됨
+            Button("시작하기") {
                 print("불러오기 버튼 눌렸음")
-            }) {
-                Text("불러오기")
-                    .typography(.title3)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 45)
-                    .background(.gray1)
-                    .foregroundColor(.gray4)
-                    .cornerRadius(4)
-                    .padding(.bottom)
             }
+            .buttonStyle(.staccatoFullWidth)
             .padding(.vertical)
+            .disabled(code.count != 36)
         }
         .padding(.horizontal, 24)
         .staccatoNavigationBar()

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/RecoverAccountView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/RecoverAccountView.swift
@@ -20,6 +20,7 @@ struct RecoverAccountView: View {
                 .multilineTextAlignment(.leading)
                 .padding(.bottom)
                 .padding(.top)
+            
             TextField(
                 "ex) bt2hnhd4-07kght-0pp2ln",
                 text: $code
@@ -32,12 +33,15 @@ struct RecoverAccountView: View {
                     code = String(newValue.prefix(36))
                 }
             }
+            
             Text("\(code.count)/36")
                 .typography(.body4)
                 .foregroundStyle(.gray3)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.bottom)
+            
             Spacer()
+            
             Button("시작하기") {
                 print("불러오기 버튼 눌렸음")
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
@@ -5,6 +5,10 @@ struct SignInView: View {
     @State private var nickName: String = ""
     @State private var isLoggedIn: Bool = false
     
+    var isButtonDisabled: Bool {
+         nickName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+     }
+    
     var body: some View {
         NavigationStack {
             VStack {
@@ -14,7 +18,6 @@ struct SignInView: View {
                     .frame(width: 176)
                     .foregroundStyle(.tint)
                     .padding(.bottom, 100)
-                
                 TextField("닉네임을 입력해주세요", text: $nickName)
                     .padding()
                     .typography(.body4)
@@ -25,24 +28,29 @@ struct SignInView: View {
                             nickName = String(newValue.prefix(20))
                         }
                     }
-                
                 Text("\(nickName.count)/20")
                     .typography(.body4)
                     .foregroundStyle(.gray3)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.bottom)
-                
                 Button("시작하기") {
                     login(nickname: nickName)
                     print("시작하기 버튼이 눌렸습니다.")
                 }
                 .buttonStyle(.staccatoFullWidth)
                 .padding(.vertical)
-
+                .disabled(isButtonDisabled)
                 NavigationLink(value: isLoggedIn) {
                     EmptyView()
                 }
                 .hidden()
+                NavigationLink(destination: RecoverAccountView()) {
+                    Text("이전 기록을 불러오려면 여기를 눌러주세요")
+                        .typography(.body4)
+                        .foregroundColor(.gray4)
+                        .underline()
+                }
+                .padding(.vertical)
             }
             .padding(.horizontal, 24)
             .navigationDestination(isPresented: $isLoggedIn) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
@@ -42,6 +42,7 @@ struct SignInView: View {
                 .buttonStyle(.staccatoFullWidth)
                 .padding(.vertical)
                 .disabled(isButtonDisabled)
+                
                 NavigationLink(value: isLoggedIn) {
                     EmptyView()
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
@@ -1,18 +1,12 @@
-//
-//  SignInView.swift
-//  Staccato-iOS
-//
-//  Created by Gyunni on 1/3/25.
-//
-
 import SwiftUI
 
 struct SignInView: View {
     
     @State private var nickName: String = ""
+    @State private var isLoggedIn: Bool = false
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 Image("staccato_login_logo")
                     .resizable()
@@ -20,6 +14,7 @@ struct SignInView: View {
                     .frame(width: 176)
                     .foregroundStyle(.tint)
                     .padding(.bottom, 100)
+                
                 TextField("닉네임을 입력해주세요", text: $nickName)
                     .padding()
                     .typography(.body4)
@@ -30,26 +25,48 @@ struct SignInView: View {
                             nickName = String(newValue.prefix(20))
                         }
                     }
+                
                 Text("\(nickName.count)/20")
                     .typography(.body4)
                     .foregroundStyle(.gray3)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.bottom)
+                
                 Button("시작하기") {
-                    //TODO: 버튼 액션 추가해야됨
+                    login(nickname: nickName)
                     print("시작하기 버튼이 눌렸습니다.")
                 }
                 .buttonStyle(.staccatoFullWidth)
                 .padding(.vertical)
-                NavigationLink(destination: RecoverAccountView()) {
-                    Text("이전 기록을 불러오려면 여기를 눌러주세요")
-                        .typography(.body4)
-                        .foregroundColor(.gray4)
-                        .underline()
+
+                NavigationLink(value: isLoggedIn) {
+                    EmptyView()
                 }
-                .padding(.vertical)
+                .hidden()
             }
             .padding(.horizontal, 24)
+            .navigationDestination(isPresented: $isLoggedIn) {
+                HomeView()
+            }
+        }
+    }
+}
+
+extension SignInView {
+    func login(nickname: String) {
+        NetworkService.shared.request(
+            endpoint: AuthorizationAPI.login(nickname: nickname),
+            responseType: LoginResponse.self
+        ) { result in
+            switch result {
+            case .success(let response):
+                AuthTokenManager.shared.saveToken(response.token)
+                DispatchQueue.main.async {
+                    self.isLoggedIn = true
+                }
+            case .failure(let error):
+                print("로그인 실패: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/SignIn/SignInView.swift
@@ -6,8 +6,8 @@ struct SignInView: View {
     @State private var isLoggedIn: Bool = false
     
     var isButtonDisabled: Bool {
-         nickName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-     }
+        nickName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
     
     var body: some View {
         NavigationStack {
@@ -18,6 +18,7 @@ struct SignInView: View {
                     .frame(width: 176)
                     .foregroundStyle(.tint)
                     .padding(.bottom, 100)
+                
                 TextField("닉네임을 입력해주세요", text: $nickName)
                     .padding()
                     .typography(.body4)
@@ -28,14 +29,15 @@ struct SignInView: View {
                             nickName = String(newValue.prefix(20))
                         }
                     }
+                
                 Text("\(nickName.count)/20")
                     .typography(.body4)
                     .foregroundStyle(.gray3)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.bottom)
+                
                 Button("시작하기") {
                     login(nickname: nickName)
-                    print("시작하기 버튼이 눌렸습니다.")
                 }
                 .buttonStyle(.staccatoFullWidth)
                 .padding(.vertical)
@@ -44,6 +46,7 @@ struct SignInView: View {
                     EmptyView()
                 }
                 .hidden()
+                
                 NavigationLink(destination: RecoverAccountView()) {
                     Text("이전 기록을 불러오려면 여기를 눌러주세요")
                         .typography(.body4)

--- a/Staccato-iOS/Staccato-iOS/Support/Info.plist
+++ b/Staccato-iOS/Staccato-iOS/Support/Info.plist
@@ -5,7 +5,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>우리의 추억을 저장하기 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>BASE_URL</key>
-	<string>https://stage.staccato.kr</string>
+	<string>$(BASE_URL)</string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>UIAppFonts</key>

--- a/Staccato-iOS/Staccato-iOS/Support/Info.plist
+++ b/Staccato-iOS/Staccato-iOS/Support/Info.plist
@@ -5,7 +5,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>우리의 추억을 저장하기 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>BASE_URL</key>
-	<string>$(BASE_URL)</string>
+	<string>https://stage.staccato.kr</string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>UIAppFonts</key>

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/AuthTokenManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/AuthTokenManager.swift
@@ -1,0 +1,30 @@
+//
+//  AuthTokenManager.swift
+//  Staccato-iOS
+//
+//  Created by 강재혁 on 2/8/25.
+//
+
+import Foundation
+
+final class AuthTokenManager {
+    static let shared = AuthTokenManager()
+    private init() {}
+
+    private let tokenKey = "authToken"
+
+    // 🔹 토큰 저장
+    func saveToken(_ token: String) {
+        UserDefaults.standard.set(token, forKey: tokenKey)
+    }
+
+    // 🔹 저장된 토큰 가져오기
+    func getToken() -> String? {
+        return UserDefaults.standard.string(forKey: tokenKey)
+    }
+
+    // 🔹 토큰 삭제
+    func clearToken() {
+        UserDefaults.standard.removeObject(forKey: tokenKey)
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Util/Network/APIs/AuthorizationAPI.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Network/APIs/AuthorizationAPI.swift
@@ -1,0 +1,45 @@
+//
+//  LoginAPI.swift
+//  Staccato-iOS
+//
+//  Created by 강재혁 on 2/8/25.
+//
+
+import Foundation
+
+enum AuthorizationAPI: APIEndpoint {
+    
+    case login(nickname: String)
+    
+    var path: String {
+        switch self {
+        case .login:
+            return "/login"
+        }
+    }
+    
+    var method: String {
+        switch self {
+        case .login:
+            return "POST"
+        }
+    }
+    
+    var parameters: [String: Any]? {
+        switch self {
+        case .login(nickname: let nickname):
+            return [
+                "nickname": nickname
+            ]
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        default:
+            return [
+                "Content-Type": "application/json"
+            ]
+        }
+    }
+}

--- a/Staccato-iOS/Staccato-iOS/Util/Network/NetworkError.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Network/NetworkError.swift
@@ -1,0 +1,15 @@
+//
+//  NetworkError.swift
+//  Staccato-iOS
+//
+//  Created by 강재혁 on 2/8/25.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case requestFailed
+    case decodingFailed
+    case unknown
+}

--- a/Staccato-iOS/Staccato-iOS/Util/Network/NetworkService.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Network/NetworkService.swift
@@ -1,0 +1,57 @@
+//
+//  NetworkService.swift
+//  Staccato-iOS
+//
+//  Created by 강재혁 on 2/8/25.
+//
+
+import Foundation
+import Alamofire
+
+final class NetworkService {
+    static let shared = NetworkService()
+    private init() {}
+    
+    func request<T: Decodable>(
+        endpoint: APIEndpoint,
+        responseType: T.Type,
+        completion: @escaping (Result<T, NetworkError>) -> Void
+    ) {
+        let baseURL = Bundle.main.infoDictionary?["BASE_URL"] as! String
+        let urlString = baseURL + endpoint.path
+        print(urlString)
+        guard let url = URL(string: urlString) else {
+            completion(.failure(.invalidURL))
+            return
+        }
+        
+        let method = HTTPMethod(rawValue: endpoint.method)
+        let parameters = endpoint.parameters
+        let headers = HTTPHeaders(endpoint.headers ?? [:])
+        
+        AF.request(
+            url, method: method,
+            parameters: parameters,
+            encoding: JSONEncoding.default,
+            headers: headers
+        )
+        .validate()
+        .responseDecodable(of: responseType) { response in
+            switch response.result {
+            case .success(let data):
+                completion(.success(data))
+            case .failure(let error):
+                print("❌ 네트워크 요청 실패: \(error.localizedDescription)")
+                print("❌ 상태 코드: \(response.response?.statusCode ?? 0)")
+                completion(.failure(.requestFailed))
+            }
+        }
+    }
+}
+
+protocol APIEndpoint {
+    var path: String { get }
+    var method: String { get }
+    var parameters: [String: Any]? { get }
+    var headers: [String: String]? { get }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #22 

## 🚩 Summary
- 텍스트 필드에 따른 "시작하기", "불러오기" 버튼 활성화
- 로그인 Authorization API 연동
- AuthTokenManger로 인증토큰 UserDefault에 저장, 불러오기, 삭제 구현

## 🙂 To Reviewer
제가 스타카토 로그인 로직을 이해 못한게 있어서 아직 미완성입니다!

## 📋 To Do

- "한글, 영어, 마침표, 언더바(_)"에 대한 유효성 검사 추가
- 로그인 실패 구현
- 이전 기록 복구 기능 구현