### PR TITLE
[Hotfix/#50] modalNavigationState 변수명 잘못 입력되어 발생한 컴파일 에러 수정

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -82,7 +82,7 @@ extension GMSMapViewRepresentable.Coordinator: GMSMapViewDelegate {
     func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
         if let userdata = marker.userData as? StaccatoCoordinateModel {
             print("tappedStaccato: \(userdata)")
-            viewModel.categoryNavigationState.navigate(to: .staccatoDetail(userdata.staccatoId))
+            viewModel.modalNavigationState.navigate(to: .staccatoDetail(userdata.staccatoId))
         } else {
             print("⚠️ No StaccatoData found for this marker.")
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -32,10 +32,12 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: GMSMapView, context: Context) {
-        print("GMSMapViewRepresentable updated")
         if viewModel.presentedStaccatos.isEmpty { // NOTE: 마커 없는 경우만 실행
             addAllStaccatoMarkers(to: uiView)
         }
+#if DEBUG
+        print("GMSMapViewRepresentable updated")
+#endif
     }
     
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -110,7 +110,7 @@ extension HomeView {
     
     private var staccatoAddButton: some View {
         Button {
-            viewModel.categoryNavigationState.navigate(to: .staccatoAdd)
+            viewModel.modalNavigationState.navigate(to: .staccatoAdd)
             // TODO: modal fullScreen mode
         } label: {
             Image(.plus)
@@ -129,7 +129,7 @@ extension HomeView {
         VStack {
             Spacer()
             
-            CategoryListView(viewModel.categoryNavigationState)
+            CategoryListView(viewModel.modalNavigationState)
                 .frame(height: modalHeight)
                 .background(Color.white)
                 .clipShape(RoundedCornerShape(corners: [.topLeft, .topRight], radius: 20))

--- a/Staccato-iOS/Staccato-iOS/Util/Network/NetworkService.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Network/NetworkService.swift
@@ -46,10 +46,6 @@ final class NetworkService {
             case .success(let data):
                 completion(.success(data))
             case .failure(let error):
-
-                    print("❌ 알 수 없는 오류: \(error.localizedDescription)")
-                }
-            } else {
                 print("❌ 알 수 없는 오류: \(error.localizedDescription)")
             }
         }


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #50 

## 🚩 Summary
- #44 에서 NavigationState 객체명을 일괄 수정했는데(CategoryList -> HomeModal)
`GMSMapViewRepresentable`, `HomeView` 파일에서 변수명 수정이 반영되지 않아서 컴파일 에러가 발생했습니다.
=> 수정했습니다.
다음부터는 더 꼼꼼히 확인 후 PR 올리겠습니다!

- NetworkService 파일에서 컴파일 오류 있는 코드 삭제했습니다.