### PR TITLE
[Feat/#60] 유저아이디 파싱, commentService - View 연결

### DIFF
--- a/Staccato-iOS/Staccato-iOS/App/Staccato_iOSApp.swift
+++ b/Staccato-iOS/Staccato-iOS/App/Staccato_iOSApp.swift
@@ -16,7 +16,7 @@ struct Staccato_iOSApp: App {
     
     var body: some Scene {
         WindowGroup {
-            MyPageView()
+            HomeView()
         }
     }
     

--- a/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// MARK: - Model
+
 struct CommentModel: Equatable {
     
     let commentId: Int64
@@ -18,5 +20,20 @@ struct CommentModel: Equatable {
     let memberImageUrl: String?
     
     let content: String
+    
+}
+
+
+// MARK: - Initializer
+
+extension CommentModel {
+    
+    init(from dto: CommentResponse) {
+        self.commentId = dto.commentId
+        self.memberId = dto.memberId
+        self.nickname = dto.nickname
+        self.memberImageUrl = dto.memberImageUrl
+        self.content = dto.content
+    }
     
 }

--- a/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
@@ -15,39 +15,8 @@ struct CommentModel {
     
     let nickname: String
     
-    let memberImage: Image?
+    let memberImageUrl: String?
     
     let content: String
-    
-}
-
-
-// TODO: 삭제
-
-extension CommentModel {
-    
-    static let dummy: [CommentModel] = [
-        CommentModel(
-            commentId: 1,
-            memberId: 1,
-            nickname: "julie",
-            memberImage: Image(.feelingHappy),
-            content: "해물라면 존맛탱구리~ 카고가 편식을 했다. 오이를 다 뺐다. 딩초 카고."
-        ),
-        CommentModel(
-            commentId: 2,
-            memberId: 2,
-            nickname: "Ruel",
-            memberImage: nil,
-            content: "바다 색깔이 너무 예뻤다. 빙티가 달려가다가 물에 빠져서 다같이 비웃어줬다ㅋㅋ 걸음마 다시 배우고 와라 빙빙"
-        ),
-        CommentModel(
-            commentId: 3,
-            memberId: 3,
-            nickname: "gyunnie",
-            memberImage: Image(.feelingScared),
-            content: "안녕하세요 차은우 입니다. 많이 힘드시죠? 조금만 더 힘을 냅시다ㅎㅎ"
-        )
-    ]
     
 }

--- a/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/Staccato/CommentModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CommentModel {
+struct CommentModel: Equatable {
     
     let commentId: Int64
     

--- a/Staccato-iOS/Staccato-iOS/Model/Staccato/StaccatoDetailModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/Staccato/StaccatoDetailModel.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// MARK: - Model
+
 struct StaccatoDetailModel: Identifiable {
     
     let id: UUID
@@ -24,5 +26,29 @@ struct StaccatoDetailModel: Identifiable {
     let address: String
     let latitude: Double
     let longitude: Double
+    
+}
+
+
+// MARK: - Initializer
+
+extension StaccatoDetailModel {
+    
+    init(from dto: GetStaccatoDetailResponse) {
+        self.id = UUID()
+        self.staccatoId = dto.staccatoId
+        self.categoryId = dto.categoryId
+        self.categoryTitle = dto.categoryTitle
+        self.startAt = dto.startAt
+        self.endAt = dto.endAt
+        self.staccatoTitle = dto.staccatoTitle
+        self.staccatoImageUrls = dto.staccatoImageUrls
+        self.visitedAt = dto.visitedAt
+        self.feeling = dto.feeling
+        self.placeName = dto.placeName
+        self.address = dto.address
+        self.latitude = dto.latitude
+        self.longitude = dto.longitude
+    }
     
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
@@ -40,7 +40,7 @@ struct CategoryListView: View {
                 .padding(.horizontal, 18)
                 .navigationDestination(for: HomeModalNavigationDestination.self) { destination in
                     switch destination {
-                    case .staccatoDetail: StaccatoDetailView(homeViewModel)
+                    case .staccatoDetail(let staccatoId): StaccatoDetailView(staccatoId)
                     case .staccatoAdd: StaccatoCreateView()
                     case .categoryDetail: CategoryDetailView()
                     case .categoryAdd: CategoryEditorView()

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -81,9 +81,6 @@ extension GMSMapViewRepresentable.Coordinator: GMSMapViewDelegate {
     
     func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
         if let userdata = marker.userData as? StaccatoCoordinateModel {
-            Task {
-                await viewModel.fetchStaccatoDetail(userdata.staccatoId)
-            }
             viewModel.modalNavigationState.navigate(to: .staccatoDetail(userdata.staccatoId))
         } else {
             print("⚠️ No StaccatoData found for this marker.")

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
@@ -316,6 +316,23 @@ private extension StaccatoDetailView {
                 .padding(.trailing, 24)
             }
         }
+        .contextMenu {
+            Button {
+                // TODO: 댓글 수정 UI 요청
+            } label: {
+                Text("수정")
+                Image(StaccatoIcon.pencilLine)
+            }
+            
+            Button {
+                // TODO: 댓글 삭제 경고 Alert 커스텀
+                viewModel.deleteComment(comment.commentId)
+            } label: {
+                Text("삭제")
+                Image(StaccatoIcon.trash)
+            }
+            .foregroundStyle(.red)
+        }
     }
     
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
@@ -207,8 +207,7 @@ private extension StaccatoDetailView {
                 .focused($isCommentFocused)
             
             Button {
-                print("버튼 클릭됨!")
-                // TODO: 서버 통신
+                viewModel.postComment(commentText)
                 commentText.removeAll()
             } label: {
                 Image(StaccatoIcon.arrowRightCircleFill)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
@@ -11,17 +11,20 @@ struct StaccatoDetailView: View {
     
     // MARK: - State Properties
     
-    @ObservedObject var homeViewModel: HomeViewModel
+    let staccatoId: Int64
+    
+    @ObservedObject var viewModel: StaccatoDetailViewModel
     
     // TODO: 수정
-    @State var userId: Int64 = 1
     @State var comments: [CommentModel] = CommentModel.dummy
     
     @State var commentText: String = ""
     @FocusState private var isCommentFocused: Bool
     
-    init(_ homeViewModel: HomeViewModel) {
-        self.homeViewModel = homeViewModel
+    init(_ staccatoId: Int64) {
+        self.staccatoId = staccatoId
+        self.viewModel = StaccatoDetailViewModel()
+        viewModel.fetchStaccatoDetail(staccatoId)
     }
     
     
@@ -50,7 +53,6 @@ struct StaccatoDetailView: View {
                     commentSection
                 }
             }
-            .id(homeViewModel.staccatoDetail?.id)
             .onTapGesture {
                 isCommentFocused = false
             }
@@ -78,7 +80,7 @@ private extension StaccatoDetailView {
     
     var imageSlider: some View {
         ImageSliderWithDot(
-            images: homeViewModel.staccatoDetail?.staccatoImageUrls ?? [],
+            images: viewModel.staccatoDetail?.staccatoImageUrls ?? [],
             imageWidth: ScreenUtils.width,
             imageHeight: ScreenUtils.width
         )
@@ -86,7 +88,7 @@ private extension StaccatoDetailView {
     }
     
     var titleLabel: some View {
-        Text(homeViewModel.staccatoDetail?.staccatoTitle ?? "")
+        Text(viewModel.staccatoDetail?.staccatoTitle ?? "")
             .typography(.title1)
             .foregroundStyle(.staccatoBlack)
             .lineLimit(.max)
@@ -96,20 +98,20 @@ private extension StaccatoDetailView {
     
     var locationSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(homeViewModel.staccatoDetail?.placeName ?? "")
+            Text(viewModel.staccatoDetail?.placeName ?? "")
                 .typography(.body1)
                 .foregroundStyle(.staccatoBlack)
                 .lineLimit(.max)
                 .multilineTextAlignment(.leading)
             
-            Text(homeViewModel.staccatoDetail?.address ?? "")
+            Text(viewModel.staccatoDetail?.address ?? "")
                 .typography(.body4)
                 .foregroundStyle(.staccatoBlack)
                 .lineLimit(.max)
                 .multilineTextAlignment(.leading)
                 .padding(.top, 8)
             
-            let visitedAt: String = homeViewModel.staccatoDetail?.visitedAt ?? ""
+            let visitedAt: String = viewModel.staccatoDetail?.visitedAt ?? ""
             let visitedAtString: String = {
                 guard visitedAt.count >= 10 else { return "" }
                 let year = visitedAt.prefix(4)
@@ -135,11 +137,11 @@ private extension StaccatoDetailView {
             HStack {
                 ForEach(FeelingType.allCases, id: \.id) { feeling in
                     Button {
-                        let previousFeeling = homeViewModel.selectedFeeling
-                        homeViewModel.selectedFeeling = feeling == homeViewModel.selectedFeeling ? nil : feeling
-                        homeViewModel.postStaccatoFeeling(homeViewModel.selectedFeeling) { isSuccess in
+                        let previousFeeling = viewModel.selectedFeeling
+                        viewModel.selectedFeeling = feeling == viewModel.selectedFeeling ? nil : feeling
+                        viewModel.postStaccatoFeeling(viewModel.selectedFeeling) { isSuccess in
                             if !isSuccess {
-                                homeViewModel.selectedFeeling = previousFeeling
+                                viewModel.selectedFeeling = previousFeeling
                             }
                         }
                         
@@ -147,7 +149,7 @@ private extension StaccatoDetailView {
                         feeling.image
                             .resizable()
                             .frame(width: 60, height: 60)
-                            .opacity(homeViewModel.selectedFeeling == feeling ? 1 : 0.3)
+                            .opacity(viewModel.selectedFeeling == feeling ? 1 : 0.3)
                     }
                 }
             }
@@ -178,7 +180,7 @@ private extension StaccatoDetailView {
                 } else {
                     VStack(spacing: 12) {
                         ForEach(comments, id: \.commentId) { comment in
-                            makeCommentView(userId: userId, comment: comment)
+                            makeCommentView(userId: viewModel.userId, comment: comment)
                         }
                     }
                     .padding(.top, 16)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
@@ -33,27 +33,38 @@ struct StaccatoDetailView: View {
 
     var body: some View {
         VStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    imageSlider
-                    
-                    titleLabel
-                    
-                    Divider()
-                    
-                    locationSection
-                    
-                    Divider()
-                    
-                    feelingSection
-                    
-                    Divider()
-                    
-                    commentSection
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        imageSlider
+                        
+                        titleLabel
+                        
+                        Divider()
+                        
+                        locationSection
+                        
+                        Divider()
+                        
+                        feelingSection
+                        
+                        Divider()
+                        
+                        commentSection
+                            .id("commentSection")
+                    }
                 }
-            }
-            .onTapGesture {
-                isCommentFocused = false
+                .onChange(of: viewModel.comments) { _,_ in
+                    if viewModel.shouldScrollToBottom {
+                        withAnimation {
+                            proxy.scrollTo("commentSection", anchor: .bottom)
+                            viewModel.shouldScrollToBottom = false
+                        }
+                    }
+                }
+                .onTapGesture {
+                    isCommentFocused = false
+                }
             }
             
             Spacer()

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/StaccatoDetail/StaccatoDetailView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct StaccatoDetailView: View {
     
     // MARK: - State Properties
@@ -15,16 +17,13 @@ struct StaccatoDetailView: View {
     
     @ObservedObject var viewModel: StaccatoDetailViewModel
     
-    // TODO: 수정
-    @State var comments: [CommentModel] = CommentModel.dummy
-    
     @State var commentText: String = ""
     @FocusState private var isCommentFocused: Bool
     
     init(_ staccatoId: Int64) {
         self.staccatoId = staccatoId
         self.viewModel = StaccatoDetailViewModel()
-        viewModel.fetchStaccatoDetail(staccatoId)
+        viewModel.getStaccatoDetail(staccatoId)
     }
     
     
@@ -166,7 +165,7 @@ private extension StaccatoDetailView {
                 .foregroundStyle(.staccatoBlack)
             
             Group {
-                if comments.isEmpty {
+                if viewModel.comments.isEmpty {
                     VStack(spacing: 10) {
                         Image(.staccatoCharacter)
                         
@@ -179,7 +178,7 @@ private extension StaccatoDetailView {
                     .padding(.bottom, 28)
                 } else {
                     VStack(spacing: 12) {
-                        ForEach(comments, id: \.commentId) { comment in
+                        ForEach(viewModel.comments, id: \.commentId) { comment in
                             makeCommentView(userId: viewModel.userId, comment: comment)
                         }
                     }
@@ -243,12 +242,22 @@ private extension StaccatoDetailView {
         }
         
         var profileImage: some View {
-            let image = comment.memberImage ?? Image(.staccatoLoginLogo)
-            return image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .clipShape(.circle)
-                .frame(width: 38, height: 38)
+            if let imageUrl = comment.memberImageUrl {
+                let image = KFImage(URL(string: imageUrl))
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipShape(.circle)
+                    .frame(width: 38, height: 38)
+                return AnyView(image)
+            } else {
+                let image = Image(.personCircleFill)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .foregroundStyle(.gray2)
+                    .clipShape(.circle)
+                    .frame(width: 38, height: 38)
+                return AnyView(image)
+            }
         }
         
         var commentView: some View {

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
@@ -9,19 +9,15 @@ import SwiftUI
 import CoreLocation
 
 class HomeViewModel: ObservableObject {
-    
+
     // MARK: - Properties
-    // Home, CategoryList
+    
     @Published var modalNavigationState = HomeModalNavigationState()
     
     @Published var staccatoCoordinates: [StaccatoCoordinateModel] = []
     var presentedStaccatos: [StaccatoCoordinateModel] = []
     
     @Published var isfetchingStaccatoList = false
-    
-    // Staccato Detail View
-    @Published var staccatoDetail: StaccatoDetailModel?
-    @Published var selectedFeeling: FeelingType?
     
     let locationManager = CLLocationManager()
     
@@ -31,14 +27,14 @@ class HomeViewModel: ObservableObject {
     init() {
         setLocationManager()
     }
-    
+
 }
 
 
 // MARK: - Location
 
 extension HomeViewModel {
-    
+
     private func setLocationManager() {
         locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
         locationManager.requestWhenInUseAuthorization()
@@ -51,7 +47,7 @@ extension HomeViewModel {
             self?.locationManager.stopUpdatingLocation() // 무한 호출 방지를 위해 0.1초 뒤 업데이트 멈춤
         }
     }
-    
+
 }
 
 
@@ -59,7 +55,7 @@ extension HomeViewModel {
 
 @MainActor
 extension HomeViewModel {
-    
+
     func fetchStaccatos() {
         Task {
             guard !isfetchingStaccatoList else {
@@ -89,53 +85,5 @@ extension HomeViewModel {
             }
         }
     }
-    
-    func fetchStaccatoDetail(_ staccatoId: Int64) {
-        Task {
-            do {
-                let response = try await STService.shared.staccatoService.getStaccatoDetail(staccatoId)
-                
-                let staccatoDetail = StaccatoDetailModel(
-                    id: UUID(),
-                    staccatoId: response.staccatoId,
-                    categoryId: response.categoryId,
-                    categoryTitle: response.categoryTitle,
-                    startAt: response.startAt,
-                    endAt: response.endAt,
-                    staccatoTitle: response.staccatoTitle,
-                    staccatoImageUrls: response.staccatoImageUrls,
-                    visitedAt: response.visitedAt,
-                    feeling: response.feeling,
-                    placeName: response.placeName,
-                    address: response.address,
-                    latitude: response.latitude,
-                    longitude: response.longitude
-                )
-                
-                self.staccatoDetail = staccatoDetail
-                self.selectedFeeling = FeelingType.from(serverKey: staccatoDetail.feeling)
-                
-            } catch {
-                print("Error fetching staccato detail: \(error.localizedDescription)")
-            }
-        }
-    }
-    
-    func postStaccatoFeeling(_ feeling: FeelingType?, isSuccess: @escaping ((Bool) -> Void)) {
-        Task {
-            do {
-                guard let staccatoDetail = staccatoDetail else {
-                    print(StaccatoError.optionalBindingFailed, ": staccatoDetail")
-                    return
-                }
-                let request = PostStaccatoFeelingRequest(feeling: feeling?.serverKey ?? FeelingType.nothing)
-                try await STService.shared.staccatoService.postStaccatoFeeling(staccatoDetail.staccatoId, requestBody: request)
-                isSuccess(true)
-            } catch {
-                print("❌ Failed to submit feeling: \(error)")
-                isSuccess(false)
-            }
-        }
-    }
-    
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -120,4 +120,30 @@ extension StaccatoDetailViewModel {
         }
     }
     
+    @MainActor
+    func updateComment(commentId: Int64, comment: String) {
+        Task {
+            do {
+                try await STService.shared.commentService.putComment(
+                    commentId,
+                    PutCommentRequest(content: comment)
+                )
+                getComments()
+            } catch {
+                print("Error on putComment: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func deleteComment(_ commentId: Int64) {
+        Task {
+            do {
+                try await STService.shared.commentService.deleteComment(commentId)
+                await getComments()
+            } catch {
+                print("Error on deleteComment: \(error.localizedDescription)")
+            }
+        }
+    }
+    
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -20,6 +20,7 @@ class StaccatoDetailViewModel: ObservableObject {
     }
     @Published var selectedFeeling: FeelingType?
     @Published var comments: [CommentModel] = []
+    @Published var shouldScrollToBottom: Bool = false
     
     let userId: Int64 = AuthTokenManager.shared.getUserId() ?? -1
     
@@ -102,6 +103,7 @@ extension StaccatoDetailViewModel {
         }
     }
     
+    @MainActor
     func postComment(_ content: String) {
         guard let staccatoDetail else { return }
         
@@ -110,7 +112,8 @@ extension StaccatoDetailViewModel {
                 try await STService.shared.commentService.postComment(
                     PostCommentRequest(staccatoId: staccatoDetail.staccatoId, content: content)
                 )
-                await self.getComments()
+                getComments()
+                shouldScrollToBottom = true
             } catch {
                 print("Error on postComment: \(error.localizedDescription)")
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -71,16 +71,9 @@ extension StaccatoDetailViewModel {
         
         Task {
             do {
-                let comment: [CommentModel] = try await STService.shared.commentService.getComments(staccatoDetail.staccatoId).comments.map {
-                    CommentModel(
-                        commentId: $0.commentId,
-                        memberId: $0.memberId,
-                        nickname: $0.nickname,
-                        memberImageUrl: $0.memberImageUrl,
-                        content: $0.content
-                    )
-                }
-                self.comments = comment
+                let response: GetCommentsResponse = try await STService.shared.commentService.getComments(staccatoDetail.staccatoId)
+                let comments: [CommentModel] = response.comments.map { CommentModel(from: $0) }
+                self.comments = comments
             } catch {
                 print("Error on getComments: \(error.localizedDescription)")
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -36,23 +36,7 @@ extension StaccatoDetailViewModel {
         Task {
             do {
                 let response = try await STService.shared.staccatoService.getStaccatoDetail(staccatoId)
-                
-                let staccatoDetail = StaccatoDetailModel(
-                    id: UUID(),
-                    staccatoId: response.staccatoId,
-                    categoryId: response.categoryId,
-                    categoryTitle: response.categoryTitle,
-                    startAt: response.startAt,
-                    endAt: response.endAt,
-                    staccatoTitle: response.staccatoTitle,
-                    staccatoImageUrls: response.staccatoImageUrls,
-                    visitedAt: response.visitedAt,
-                    feeling: response.feeling,
-                    placeName: response.placeName,
-                    address: response.address,
-                    latitude: response.latitude,
-                    longitude: response.longitude
-                )
+                let staccatoDetail = StaccatoDetailModel(from: response)
                 self.staccatoDetail = staccatoDetail
                 self.selectedFeeling = FeelingType.from(serverKey: staccatoDetail.feeling)
             } catch {

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -102,4 +102,19 @@ extension StaccatoDetailViewModel {
         }
     }
     
+    func postComment(_ content: String) {
+        guard let staccatoDetail else { return }
+        
+        Task {
+            do {
+                try await STService.shared.commentService.postComment(
+                    PostCommentRequest(staccatoId: staccatoDetail.staccatoId, content: content)
+                )
+                await self.getComments()
+            } catch {
+                print("Error on postComment: \(error.localizedDescription)")
+            }
+        }
+    }
+    
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/StaccatoDetail/StaccatoDetailViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  StaccatoDetailViewModel.swift
+//  Staccato-iOS
+//
+//  Created by 김유림 on 3/27/25.
+//
+
+import Foundation
+
+class StaccatoDetailViewModel: ObservableObject {
+    
+    // MARK: - Properties
+    
+    @Published var staccatoDetail: StaccatoDetailModel?
+    @Published var selectedFeeling: FeelingType?
+    let userId: Int64 = AuthTokenManager.shared.getUserId() ?? -1
+    
+}
+
+
+// MARK: - Network
+
+extension StaccatoDetailViewModel {
+    
+    @MainActor
+    func fetchStaccatoDetail(_ staccatoId: Int64) {
+        Task {
+            do {
+                let response = try await STService.shared.staccatoService.getStaccatoDetail(staccatoId)
+                
+                let staccatoDetail = StaccatoDetailModel(
+                    id: UUID(),
+                    staccatoId: response.staccatoId,
+                    categoryId: response.categoryId,
+                    categoryTitle: response.categoryTitle,
+                    startAt: response.startAt,
+                    endAt: response.endAt,
+                    staccatoTitle: response.staccatoTitle,
+                    staccatoImageUrls: response.staccatoImageUrls,
+                    visitedAt: response.visitedAt,
+                    feeling: response.feeling,
+                    placeName: response.placeName,
+                    address: response.address,
+                    latitude: response.latitude,
+                    longitude: response.longitude
+                )
+                
+                self.staccatoDetail = staccatoDetail
+                self.selectedFeeling = FeelingType.from(serverKey: staccatoDetail.feeling)
+                
+                print("🥑 staccatoDetail.id: \(staccatoDetail.id)")
+                
+            } catch {
+                print("Error fetching staccato detail: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func postStaccatoFeeling(_ feeling: FeelingType?, isSuccess: @escaping ((Bool) -> Void)) {
+        Task {
+            do {
+                guard let staccatoDetail = staccatoDetail else {
+                    print(StaccatoError.optionalBindingFailed, ": staccatoDetail")
+                    return
+                }
+                let request = PostStaccatoFeelingRequest(feeling: feeling?.serverKey ?? FeelingType.nothing)
+                try await STService.shared.staccatoService.postStaccatoFeeling(staccatoDetail.staccatoId, requestBody: request)
+                isSuccess(true)
+            } catch {
+                print("❌ Failed to submit feeling: \(error)")
+                isSuccess(false)
+            }
+        }
+    }
+    
+}

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/AuthTokenManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/AuthTokenManager.swift
@@ -8,14 +8,20 @@
 import Foundation
 
 final class AuthTokenManager {
+
     static let shared = AuthTokenManager()
     private init() {}
 
     private let tokenKey = "authToken"
+    private let userIdKey = "userId"
 
-    // 🔹 토큰 저장
+    // 🔹 토큰(+유저아이디) 저장
     func saveToken(_ token: String) {
         UserDefaults.standard.set(token, forKey: tokenKey)
+        
+        if let userId = parseUserID(from: token) {
+            UserDefaults.standard.set(userId, forKey: userIdKey)
+        }
     }
 
     // 🔹 저장된 토큰 가져오기
@@ -23,8 +29,48 @@ final class AuthTokenManager {
         return UserDefaults.standard.string(forKey: tokenKey)
     }
 
-    // 🔹 토큰 삭제
+    // 🔹 저장된 유저 아이디 가져오기
+    func getUserId() -> Int64? {
+        return UserDefaults.standard.object(forKey: userIdKey) as? Int64
+    }
+
+    // 🔹 토큰(+유저아이디) 삭제
     func clearToken() {
         UserDefaults.standard.removeObject(forKey: tokenKey)
+        UserDefaults.standard.removeObject(forKey: userIdKey)
     }
+
+}
+
+
+// MARK: - Helper
+
+private extension AuthTokenManager {
+
+    func parseUserID(from token: String) -> Int64? {
+        let parts = token.split(separator: ".")
+        guard parts.count > 1 else { return nil } // payload가 없으면 nil 반환
+
+        let payload = String(parts[1])
+
+        // Base64 디코딩
+        guard let data = Data(base64Encoded: payload.padding(toLength: ((payload.count+3)/4)*4,
+                                                             withPad: "=",
+                                                             startingAt: 0),
+                              options: .ignoreUnknownCharacters) else {
+            print("❌userId Base64 디코딩 실패")
+            return nil
+        }
+        
+        // JSON 디코딩
+        if let json = try? JSONSerialization.jsonObject(with: data),
+           let dict = json as? [String: Any],
+           let userId = dict["id"] as? Int64 {
+            return userId
+        }
+
+        print("❌ userId JSON 디코딩 실패")
+        return nil
+    }
+
 }

--- a/Staccato-iOS/Staccato-iOS/Util/Theme/StaccatoIcon.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Theme/StaccatoIcon.swift
@@ -48,6 +48,7 @@ enum StaccatoIcon: String {
     
     // MARK: - Staccato Detail
     case arrowRightCircleFill = "arrow.right.circle.fill"
+    case trash = "trash"
     
     // MARK: - Home
     case plus = "plus"


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #60 

## 🚩 Summary
- 유저 ID 파싱
- StaccatoDetail VM 분리
- 댓글 Get, Post, Delete 서비스 연결

## 📸 Screenshots
| 1.댓글 작성 | 2. 댓글 삭제 |
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/9ef25d03-5590-44bc-8447-4e74108b3ed1" width="250">|<img src="https://github.com/user-attachments/assets/b68e1ca1-a5ce-474e-8ccf-a2ddc56f0166" width ="250">|


## 🙂 To Reviewer
- 댓글 수정은 UI가 없어서 보류했습니다.
- 댓글을 삭제할 때 경고 Alert을 띄워야하는데, 추후 다른 브랜치에서 Alert 커스텀 후 수정하겠습니다.

## 📋 To Do
