### PR TITLE
[Refactor/#64] Navigation 로직 개선

### DIFF
--- a/Staccato-iOS/Staccato-iOS/App/Staccato_iOSApp.swift
+++ b/Staccato-iOS/Staccato-iOS/App/Staccato_iOSApp.swift
@@ -11,13 +11,16 @@ import GoogleMaps
 
 @main
 struct Staccato_iOSApp: App {
-    
+
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
+    private let navigationState = NavigationState()
+
     var body: some Scene {
         WindowGroup {
             HomeView()
+                .environment(navigationState)
         }
     }
-    
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoNavigationBar.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoNavigationBar.swift
@@ -7,23 +7,41 @@
 
 import SwiftUI
 
+// MARK: - Enums
+
+enum STNavigationBarType {
+    case navigation, modal
+}
+
+enum TitlePosition {
+    case center, leading
+}
+
+
+// MARK: - ViewModifier
+
 struct StaccatoNavigationBar<T: View>: ViewModifier {
+    
+    @Environment(NavigationState.self) var navigationState
     @Environment(\.dismiss) var dismiss
 
     let title: String?
     let subtitle: String?
     let trailingButtons: T
     let titlePosition: TitlePosition
+    let barType: STNavigationBarType
 
     init(
         title: String?,
         subtitle: String?,
         titlePosition: TitlePosition = .leading,
+        barType: STNavigationBarType,
         @ViewBuilder trailingButtons: () -> T
     ) {
         self.title = title
         self.subtitle = subtitle
         self.titlePosition = titlePosition
+        self.barType = barType
         self.trailingButtons = trailingButtons()
     }
 
@@ -32,7 +50,7 @@ struct StaccatoNavigationBar<T: View>: ViewModifier {
             ZStack {
                 HStack(spacing: 16) {
                     Button  {
-                        dismiss()
+                        barType == .navigation ? navigationState.dismiss() : dismiss()
                     } label: {
                         Image(.chevronLeft)
                             .resizable()
@@ -96,9 +114,6 @@ struct StaccatoNavigationBar<T: View>: ViewModifier {
     }
 }
 
-enum TitlePosition {
-    case center, leading
-}
 
 #Preview("Position - Leading") {
     NavigationStack {
@@ -138,7 +153,11 @@ enum TitlePosition {
     }
 }
 
+
+// MARK: - Ex+View
+
 extension View {
+
     func staccatoNavigationBar<T: View>(
         title: String? = nil,
         subtitle: String? = nil,
@@ -146,7 +165,7 @@ extension View {
         @ViewBuilder trailingButtons: () -> T
     ) -> some View {
         self
-            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, trailingButtons: trailingButtons))
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, barType: .navigation, trailingButtons: trailingButtons))
     }
 
     func staccatoNavigationBar(
@@ -155,6 +174,26 @@ extension View {
         titlePosition: TitlePosition = .leading
     ) -> some View {
         self
-            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, trailingButtons: { }))
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, barType: .navigation, trailingButtons: { }))
     }
+
+    func staccatoModalBar<T: View>(
+        title: String? = nil,
+        subtitle: String? = nil,
+        titlePosition: TitlePosition = .leading,
+        @ViewBuilder trailingButtons: () -> T
+    ) -> some View {
+        self
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, barType: .modal, trailingButtons: trailingButtons))
+    }
+
+    func staccatoModalBar(
+        title: String? = nil,
+        subtitle: String? = nil,
+        titlePosition: TitlePosition = .leading
+    ) -> some View {
+        self
+            .modifier(StaccatoNavigationBar(title: title, subtitle: subtitle, titlePosition: titlePosition, barType: .modal, trailingButtons: { }))
+    }
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
@@ -13,7 +13,6 @@ struct CategoryListView: View {
     @Bindable var bindableNavigationState: NavigationState
     
     @StateObject private var viewModel = CategoryListViewModel()
-    @ObservedObject var homeViewModel: HomeViewModel
     @State private var selectedCategory: CategoryModel?
     @State private var isDetailPresented: Bool = false
     @State private var isSortFilterMenuPresented: Bool = false
@@ -21,8 +20,7 @@ struct CategoryListView: View {
     
     // MARK: - Initializer
     
-    init(_ homeViewModel: HomeViewModel, navigationState: NavigationState) {
-        self.homeViewModel = homeViewModel
+    init(_ navigationState: NavigationState) {
         self.bindableNavigationState = navigationState
     }
     

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/CategoryList/CategoryListView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct CategoryListView: View {
     
+    @Environment(NavigationState.self) var navigationState
+    @Bindable var bindableNavigationState: NavigationState
+    
     @StateObject private var viewModel = CategoryListViewModel()
     @ObservedObject var homeViewModel: HomeViewModel
     @State private var selectedCategory: CategoryModel?
@@ -18,8 +21,9 @@ struct CategoryListView: View {
     
     // MARK: - Initializer
     
-    init(_ homeViewModel: HomeViewModel) {
+    init(_ homeViewModel: HomeViewModel, navigationState: NavigationState) {
         self.homeViewModel = homeViewModel
+        self.bindableNavigationState = navigationState
     }
     
     
@@ -28,8 +32,7 @@ struct CategoryListView: View {
     var body: some View {
         VStack {
             modalTop
-            
-            NavigationStack(path: $homeViewModel.modalNavigationState.path) {
+            NavigationStack(path: $bindableNavigationState.path) {
                 VStack(spacing: 0) {
                     titleHStack
                         .padding(.top, 22)
@@ -124,7 +127,7 @@ private extension CategoryListView {
     
     var categoryAddButton: some View {
         Button("추가") {
-            homeViewModel.modalNavigationState.navigate(to: .categoryAdd)
+            navigationState.navigate(to: .categoryAdd)
             // TODO: modal fullScreen mode
         }
         .buttonStyle(.staccatoCapsule(
@@ -143,7 +146,7 @@ private extension CategoryListView {
                 ForEach(viewModel.categories, id: \.id) { categoryInfo in
                     Button {
                         selectedCategory = categoryInfo
-                        homeViewModel.modalNavigationState.navigate(to: .categoryDetail)
+                        navigationState.navigate(to: .categoryDetail)
                     } label: {
                         CategoryListCell(categoryInfo)
                     }
@@ -151,5 +154,5 @@ private extension CategoryListView {
             }
         }
     }
-    
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -49,17 +49,15 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
 extension GMSMapViewRepresentable {
     
     func makeCoordinator() -> Coordinator {
-        return Coordinator(self, viewModel, navigationState)
+        return Coordinator(self, navigationState)
     }
     
     final class Coordinator: NSObject {
         let parent: GMSMapViewRepresentable
-        let viewModel: HomeViewModel
         let navigationState: NavigationState
         
-        init(_ parent: GMSMapViewRepresentable, _ viewModel: HomeViewModel, _ navigationState: NavigationState) {
+        init(_ parent: GMSMapViewRepresentable, _ navigationState: NavigationState) {
             self.parent = parent
-            self.viewModel = parent.viewModel
             self.navigationState = parent.navigationState
         }
     }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct GMSMapViewRepresentable: UIViewRepresentable {
     
     @ObservedObject var viewModel: HomeViewModel
+    @Environment(NavigationState.self) var navigationState
     
     private let mapView = GMSMapView()
     
@@ -48,16 +49,18 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
 extension GMSMapViewRepresentable {
     
     func makeCoordinator() -> Coordinator {
-        return Coordinator(self, viewModel)
+        return Coordinator(self, viewModel, navigationState)
     }
     
     final class Coordinator: NSObject {
         let parent: GMSMapViewRepresentable
         let viewModel: HomeViewModel
+        let navigationState: NavigationState
         
-        init(_ parent: GMSMapViewRepresentable, _ viewModel: HomeViewModel) {
+        init(_ parent: GMSMapViewRepresentable, _ viewModel: HomeViewModel, _ navigationState: NavigationState) {
             self.parent = parent
             self.viewModel = parent.viewModel
+            self.navigationState = parent.navigationState
         }
     }
     
@@ -69,7 +72,7 @@ extension GMSMapViewRepresentable.Coordinator: CLLocationManagerDelegate {
         let location: CLLocation = locations.last!
         print("📍Location: \(location)")
         
-        let camera = GMSCameraPosition.camera(withTarget: location.coordinate, zoom: 15)
+        let camera = GMSCameraPosition.camera(withTarget: location.coordinate, zoom: 5)
         
         parent.mapView.animate(to: camera)
     }
@@ -81,7 +84,7 @@ extension GMSMapViewRepresentable.Coordinator: GMSMapViewDelegate {
     
     func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
         if let userdata = marker.userData as? StaccatoCoordinateModel {
-            viewModel.modalNavigationState.navigate(to: .staccatoDetail(userdata.staccatoId))
+            navigationState.navigate(to: .staccatoDetail(userdata.staccatoId))
         } else {
             print("⚠️ No StaccatoData found for this marker.")
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -10,47 +10,48 @@ import GoogleMaps
 import SwiftUI
 
 struct HomeView: View {
-    
+
     // MARK: - Properties
     //NOTE: 뷰모델
     @StateObject private var viewModel = HomeViewModel()
-    
+
     // NOTE: 뷰
     private var mapView: GMSMapViewRepresentable {
         GMSMapViewRepresentable(viewModel)
     }
-    
+
     // NOTE: 모달 크기
     @State private var modalHeight: CGFloat = HomeModalSize.medium.height
     @State private var dragOffset: CGFloat = 120 / 640 * ScreenUtils.height
-    
+
     // NOTE: 화면 전환
+    @Environment(NavigationState.self) var navigationState
     @State private var isMyPagePresented = false
-    
+
     // NOTE: 위치 접근 권한
     @State private var locationAuthorizationManager = LocationAuthorizationManager.shared
-    
-    
+
+
     // MARK: - Body
-    
+
     var body: some View {
         ZStack(alignment: .topLeading) {
             mapView
                 .edgesIgnoringSafeArea(.all)
                 .padding(.bottom, modalHeight - 40) // TODO: 리팩토링 - 모달 크기 바뀔 때마다 updateUIView 호출됨
-            
+
             myPageButton
                 .padding(10)
             
             myLocationButton
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .topTrailing)
-            
+
             staccatoAddButton
                 .padding(.trailing, 12)
                 .padding(.bottom, modalHeight - 20)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-            
+
             categoryListModal
                 .edgesIgnoringSafeArea(.bottom)
         }
@@ -68,14 +69,14 @@ struct HomeView: View {
             MyPageView()
         }
     }
-    
+
 }
 
 
 // MARK: - UI Components
 
 extension HomeView {
-    
+
     private var myPageButton: some View {
         Button {
             isMyPagePresented = true
@@ -92,7 +93,7 @@ extension HomeView {
                 }
         }
     }
-    
+
     private var myLocationButton: some View {
         Button {
             viewModel.updateLocationForOneSec()
@@ -107,10 +108,10 @@ extension HomeView {
         .clipShape(.circle)
         .shadow(radius: 2)
     }
-    
+
     private var staccatoAddButton: some View {
         Button {
-            viewModel.modalNavigationState.navigate(to: .staccatoAdd)
+            navigationState.navigate(to: .staccatoAdd)
             // TODO: modal fullScreen mode
         } label: {
             Image(.plus)
@@ -124,12 +125,12 @@ extension HomeView {
         .clipShape(.circle)
         .shadow(radius: 4, y: 4)
     }
-    
+
     private var categoryListModal: some View {
         VStack {
             Spacer()
 
-            CategoryListView(viewModel)
+            CategoryListView(viewModel, navigationState: navigationState)
                 .frame(height: modalHeight)
                 .background(Color.white)
                 .clipShape(RoundedCornerShape(corners: [.topLeft, .topRight], radius: 20))
@@ -154,5 +155,5 @@ extension HomeView {
                 )
         }
     }
-    
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -130,7 +130,7 @@ extension HomeView {
         VStack {
             Spacer()
 
-            CategoryListView(viewModel, navigationState: navigationState)
+            CategoryListView(navigationState)
                 .frame(height: modalHeight)
                 .background(Color.white)
                 .clipShape(RoundedCornerShape(corners: [.topLeft, .topRight], radius: 20))

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
@@ -39,7 +39,7 @@ struct MyPageView: View {
             
             Spacer()
         }
-        .staccatoNavigationBar(title: "마이페이지", titlePosition: .center)
+        .staccatoModalBar(title: "마이페이지", titlePosition: .center)
         .overlay(
             Group {
                 if showToast {

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
@@ -12,8 +12,6 @@ class HomeViewModel: ObservableObject {
 
     // MARK: - Properties
     
-    @Published var modalNavigationState = HomeModalNavigationState()
-    
     @Published var staccatoCoordinates: [StaccatoCoordinateModel] = []
     var presentedStaccatos: [StaccatoCoordinateModel] = []
     

--- a/Staccato-iOS/Staccato-iOS/Util/NavigationState/NavigationState.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/NavigationState/NavigationState.swift
@@ -21,22 +21,31 @@ enum HomeModalNavigationDestination: Hashable {
 // MARK: - Navigation States
 
 @Observable
-class HomeModalNavigationState {
+final class NavigationState {
+
     var path = NavigationPath()
-    var lastDestination: HomeModalNavigationDestination?
-    
+    private(set) var destinations: [HomeModalNavigationDestination] = []
+
     func navigate(to destination: HomeModalNavigationDestination) {
-        // NOTE: 지도 마커 클릭하여 스타카토 -> 스타카토로 가는 경우, 스타카토 경로를 누적하지 않음
         if case .staccatoDetail = destination,
-           case .staccatoDetail = lastDestination {
-            if path.count > 0 {
-                path.removeLast()
-            }
-            path.append(destination)
-            lastDestination = destination
-        } else {
-            path.append(destination)
-            lastDestination = destination
+           case .staccatoDetail = destinations.last,
+           !path.isEmpty {
+            path.removeLast()
+            destinations.removeLast()
         }
+        path.append(destination)
+        destinations.append(destination)
     }
+
+    func dismiss() {
+        guard !path.isEmpty else { return }
+        path.removeLast()
+        destinations.removeLast()
+    }
+
+    func dismissToRoot() {
+        path.removeLast(path.count)
+        destinations.removeAll()
+    }
+
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #64

## 🚩 Summary
- 기존에는 Navigation Path를 관리하는 로직이 HomeVM에 있어서, 네비게이션이 필요한 뷰마다 HomeVM을 질질 끌고다녀야하는 문제가 있었습니다. (파라미터 주입의 연속....ㅜㅜ)
  -> 해결: Navigation Path를 전역으로 관리하는 방향으로 수정하여, 불필요한 파라미터 주입을 막았습니다.

- 홈 지도에서 staccato 마커를 클릭할 때, staccato -> staccato로 네비게이션 되는 경우, staccato path가 누적되지 않도록 했었는데, 이 로직에 허점이 있어 개선했습니다.
  - lastDestination 대신 destinations를 배열로 관리
  - NavigationBar의 dismiss 로직 수정

## 🙂 To Reviewer
주요 변경사항은 코멘트 남기겠습니다.