### PR TITLE
[Fix/#115] 스타카토 삭제시 리스트에 반영 안되는 오류 해결

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -89,17 +89,12 @@ struct StaccatoDetailView: View {
                         .confirmCancelAlert(
                             title: "삭제하시겠습니까?",
                             message: "삭제를 누르면 복구할 수 없습니다") {
-                                Task {
-                                    do {
-                                        try await viewModel.deleteStaccato(staccatoId)
-                                        if let indexToRemove = homeViewModel.staccatos.firstIndex(where: { $0.id == staccatoId }) {
-                                            homeViewModel.staccatos.remove(at: indexToRemove)
-                                        }
-                                        navigationState.dismiss()
-                                    } catch {
-                                        print("삭제 실패: \(error.localizedDescription)")
-                                        navigationState.dismiss()
+                                viewModel.deleteStaccato(staccatoId) {isSuccess in
+                                    if isSuccess,
+                                       let indexToRemove = homeViewModel.staccatos.firstIndex(where: { $0.id == staccatoId }) {
+                                        homeViewModel.staccatos.remove(at: indexToRemove)
                                     }
+                                    navigationState.dismiss()
                                 }
                             }
                     )

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -89,13 +89,18 @@ struct StaccatoDetailView: View {
                         .confirmCancelAlert(
                             title: "삭제하시겠습니까?",
                             message: "삭제를 누르면 복구할 수 없습니다") {
-                                viewModel.delteStaccato(staccatoId)
-                                navigationState.dismiss()
-                                // TODO: deleteStaccato 메소드 내부로 옮겨서 성공했을 경우만 실행하기
-                                if let indexToRemove = homeViewModel.staccatos.firstIndex(where: { $0.id == staccatoId }) {
-                                    homeViewModel.staccatos.remove(at: indexToRemove)
+                                Task {
+                                    do {
+                                        try await viewModel.deleteStaccato(staccatoId)
+                                        if let indexToRemove = homeViewModel.staccatos.firstIndex(where: { $0.id == staccatoId }) {
+                                            homeViewModel.staccatos.remove(at: indexToRemove)
+                                        }
+                                        navigationState.dismiss()
+                                    } catch {
+                                        print("삭제 실패: \(error.localizedDescription)")
+                                        navigationState.dismiss()
+                                    }
                                 }
-                                
                             }
                     )
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoDetailViewModel.swift
@@ -47,8 +47,17 @@ extension StaccatoDetailViewModel {
         }
     }
 
-    func deleteStaccato(_ staccatoId: Int64) async throws {
-        try await STService.shared.staccatoService.deleteStaccato(staccatoId)
+    @MainActor
+    func deleteStaccato(_ staccatoId: Int64, isSuccess: @escaping ((Bool) -> Void)) {
+        Task {
+            do {
+                try await STService.shared.staccatoService.deleteStaccato(staccatoId)
+                isSuccess(true)
+            } catch {
+                print("Error deleting staccato: \(error.localizedDescription)")
+                isSuccess(false)
+            }
+        }
     }
 
     func postStaccatoFeeling(_ feeling: FeelingType?, isSuccess: @escaping ((Bool) -> Void)) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoDetailViewModel.swift
@@ -47,14 +47,8 @@ extension StaccatoDetailViewModel {
         }
     }
 
-    func delteStaccato(_ staccatoId: Int64) {
-        Task {
-            do {
-                try await STService.shared.staccatoService.deleteStaccato(staccatoId)
-            } catch {
-                print("Error deleting staccato: \(error.localizedDescription)")
-            }
-        }
+    func deleteStaccato(_ staccatoId: Int64) async throws {
+        try await STService.shared.staccatoService.deleteStaccato(staccatoId)
     }
 
     func postStaccatoFeeling(_ feeling: FeelingType?, isSuccess: @escaping ((Bool) -> Void)) {


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #115 

## 🚩 Summary
- 스타카토 삭제시 리스트에 반영 안되는 오류 해결

## 🙂 To Reviewer
스타카토 삭제가 비동기적으로 처리되면서, 삭제 완료 전에 모달이 닫혀 삭제가 안된 것 처럼 보이는 문제가 있었습니다.(모달이 닫히면 리스트를 리로딩함)
completion 핸들러를 달아서 스타카토 삭제가 완료되는 시점을 뷰에서 알 수 있게 수정하였습니다.
