### PR TITLE
[Fix/#117] 스타카토 상세 - Comment UI QA 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,4 @@ iOSInjectionProject/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
-Config.xcconfig
-Release.xcconfig
-Debug.xcconfig
+*.xcconfig

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -77,7 +77,7 @@ struct StaccatoTextFieldStyle: TextFieldStyle {
     func _body(configuration: TextField<_Label>) -> some View {
         HStack {
             configuration
-                .typography(.body1)
+                .typography(.body2)
                 .foregroundStyle(.staccatoBlack)
                 .padding(12)
                 .autocorrectionDisabled()

--- a/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Components/StaccatoTextField.swift
@@ -85,7 +85,7 @@ struct StaccatoTextFieldStyle: TextFieldStyle {
 
             Spacer()
         }
-        .frame(height: 45)
+        .frame(minHeight: 45)
         .background(
             RoundedRectangle(cornerRadius: 5)
                 .foregroundStyle(.gray1)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -306,18 +306,20 @@ private extension StaccatoDetailView {
         let placeholder = "코멘트 입력하기"
         
         return HStack(spacing: 6) {
-            TextField("", text: $commentText)
+            TextField("", text: $commentText, axis: .vertical)
+                .focused($isCommentFocused)
+                .lineLimit(4)
                 .textFieldStyle(StaccatoTextFieldStyle())
-                .overlay(alignment: .topLeading) {
+
+                .overlay(alignment: .leading) {
                     if !isCommentFocused && commentText.isEmpty {
                         Text(placeholder)
-                            .padding(12)
+                            .padding(.leading, 15)
                             .typography(.body1)
                             .foregroundStyle(.gray3)
                     }
                 }
-                .focused($isCommentFocused)
-            
+
             Button {
                 viewModel.postComment(commentText)
                 commentText.removeAll()
@@ -380,25 +382,24 @@ private extension StaccatoDetailView {
                 }
             }()
             
-            return ZStack {
-                Rectangle()
-                    .foregroundStyle(.gray1)
-                    .clipShape(RoundedCornerShape(corners: corners, radius: 10))
-                
-                Text(comment.content)
-                    .typography(.body3)
-                    .foregroundStyle(.staccatoBlack)
-                    .lineLimit(.max)
-                    .multilineTextAlignment(.leading)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-            }
+            return Text(comment.content)
+                .typography(.body3)
+                .foregroundStyle(.staccatoBlack)
+                .lineLimit(.max)
+                .multilineTextAlignment(.leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedCornerShape(corners: corners, radius: 10)
+                        .foregroundStyle(.gray1)
+                )
         }
         
         // actual comment view
         return Group {
             if isFromUser {
                 HStack(alignment: .top, spacing: 6) {
+                    Spacer()
                     VStack(alignment: .trailing, spacing: 6) {
                         nicknameText
                         commentView
@@ -413,6 +414,7 @@ private extension StaccatoDetailView {
                         nicknameText
                         commentView
                     }
+                    Spacer()
                 }
                 .padding(.trailing, 24)
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -308,14 +308,14 @@ private extension StaccatoDetailView {
         return HStack(spacing: 6) {
             TextField("", text: $commentText, axis: .vertical)
                 .focused($isCommentFocused)
-                .lineLimit(4)
                 .textFieldStyle(StaccatoTextFieldStyle())
+                .lineLimit(4)
 
                 .overlay(alignment: .leading) {
                     if !isCommentFocused && commentText.isEmpty {
                         Text(placeholder)
                             .padding(.leading, 15)
-                            .typography(.body1)
+                            .typography(.body2)
                             .foregroundStyle(.gray3)
                     }
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -166,7 +166,7 @@ private extension StaccatoDetailView {
 // MARK: - UI Components
 
 private extension StaccatoDetailView {
-    
+
     var imageSlider: some View {
         ImageSliderWithDot(
             images: viewModel.staccatoDetail?.staccatoImageUrls ?? [],
@@ -268,8 +268,7 @@ private extension StaccatoDetailView {
         }
         .padding(.horizontal, horizontalInset)
     }
-    
-    
+
     var commentSection: some View {
         VStack(alignment: .leading) {
             Text("코멘트")
@@ -301,7 +300,7 @@ private extension StaccatoDetailView {
         }
         .padding(.horizontal, horizontalInset)
     }
-    
+
     var commentTypingView: some View {
         let placeholder = "코멘트 입력하기"
         
@@ -320,40 +319,46 @@ private extension StaccatoDetailView {
                     }
                 }
 
-            Button {
-                viewModel.postComment(commentText)
-                commentText.removeAll()
-            } label: {
-                Image(StaccatoIcon.arrowRightCircleFill)
-                    .resizable()
-                    .scaledToFit()
-                    .foregroundStyle(commentText.isEmpty ? .gray3 : .accent)
-                    .frame(width: 30, height: 30)
-            }
-            .disabled(commentText.isEmpty)
+            commentSubmitButton
         }
         .padding(.horizontal, 10)
         .padding(.top, 10)
     }
-    
+
+    var commentSubmitButton: some View {
+        let isValid = !commentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        
+        return Button {
+            viewModel.postComment(commentText)
+            commentText.removeAll()
+        } label: {
+            Image(StaccatoIcon.arrowRightCircleFill)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(isValid ? .accent : .gray3)
+                .frame(width: 30, height: 30)
+        }
+        .disabled(!isValid)
+    }
+
 }
 
 
 // MARK: - UI Generator
 
 private extension StaccatoDetailView {
-    
+
     func makeCommentView(userId: Int64, comment: CommentModel) -> some View {
-        
+
         // properties
         let isFromUser: Bool = userId == comment.memberId
-        
+
         var nicknameText: some View {
             Text(comment.nickname)
                 .typography(.body4)
                 .foregroundStyle(.staccatoBlack)
         }
-        
+
         var profileImage: some View {
             if let imageUrl = comment.memberImageUrl {
                 let image = KFImage(URL(string: imageUrl))
@@ -372,7 +377,7 @@ private extension StaccatoDetailView {
                 return AnyView(image)
             }
         }
-        
+
         var commentView: some View {
             let corners: UIRectCorner = {
                 if isFromUser {
@@ -381,7 +386,7 @@ private extension StaccatoDetailView {
                     return [.topRight, .bottomLeft, .bottomRight]
                 }
             }()
-            
+
             return Text(comment.content)
                 .typography(.body3)
                 .foregroundStyle(.staccatoBlack)
@@ -394,7 +399,7 @@ private extension StaccatoDetailView {
                         .foregroundStyle(.gray1)
                 )
         }
-        
+
         // actual comment view
         return Group {
             if isFromUser {
@@ -442,5 +447,5 @@ private extension StaccatoDetailView {
             .foregroundStyle(.red)
         }
     }
-    
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoDetailView.swift
@@ -126,8 +126,8 @@ struct StaccatoDetailView: View {
                 StaccatoEditorView(staccato: staccatoDetail)
             }
         }
-
     }
+
 }
 
 

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
@@ -24,13 +24,13 @@ final class HomeModalManager {
     }
     
     func setFinalSize(translationAmount: CGFloat) {
-        // 위로 10 이상 드래그한 경우
-        if translationAmount < -10 {
+        // 위로 5 이상 드래그한 경우
+        if translationAmount < -5 {
             modalSize = modalSize.upperSize
         }
         
-        // 아래로 10 이상 드래그한 경우
-        else if translationAmount > 10 {
+        // 아래로 5 이상 드래그한 경우
+        else if translationAmount > 5 {
             modalSize = modalSize.lowerSize
             dismissKeyboard() // small, medium 사이즈에서 키보드 비활성화
         }

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
@@ -24,13 +24,22 @@ final class HomeModalManager {
     }
     
     func setFinalSize(translationAmount: CGFloat) {
-        if translationAmount < -10 { // 위로 10 이상 드래그한 경우
+        // 위로 10 이상 드래그한 경우
+        if translationAmount < -10 {
             modalSize = modalSize.upperSize
-        } else if translationAmount > 10 { // 아래로 10 이상 드래그한 경우
+        }
+        
+        // 아래로 10 이상 드래그한 경우
+        else if translationAmount > 10 {
             modalSize = modalSize.lowerSize
+            dismissKeyboard() // small, medium 사이즈에서 키보드 비활성화
         }
 
         modalHeight = modalSize.height
+    }
+    
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 
     enum ModalSize: CaseIterable {

--- a/Staccato-iOS/Staccato-iOS/Util/Theme/StaccatoFont.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Theme/StaccatoFont.swift
@@ -65,8 +65,10 @@ enum StaccatoFont {
 
     var lineSpacing: CGFloat {
         switch self {
-        case .title1, .title2, .body1, .body2:
+        case .title1:
             return 25 - self.size
+        case .title2, .body1, .body2:
+            return 20 - self.size
         case .body3:
             return 18 - self.size
         case .title3, .body4, .body5:


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #117 

## 🚩 Summary
- **StaccatoTextField** 객체 수정
  - height = 48를 minHeight = 48로 변경했습니다. (-> 여러 줄 입력 가능하도록)
- **스타카토 상세**
  - 텍스트필드에서 개행이 가능하게했으며, 텍스트필드 높이는 4줄정도가 보여지도록 했습니다
  - 말풍선 너비가 텍스트 너비에 따라 유동적으로 변하도록 수정했습니다.
  - 말풍선 텍스트 왼쪽정렬 했습니다. 
  - 공백, 개행만 있을 경우, 보내기버튼 비활성화했습니다.
- **StaccatoFont** lineSpacing 값 업데이트
- gitignore 개선
  - 추후 같은 실수 방지를 위해 Config.xcconfig, Release.xcconfig... 이런식으로 직접 명시하던 걸 `*.xcconfig`로 통합했습니다.

## 📸 Screenshots
| 코멘트 작성 | 공백/개행 보내기버튼 비활성화|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/342cf645-2af5-4bca-b28e-24cb13fb8549" width="250">| <img src="https://github.com/user-attachments/assets/f49dff05-fb40-4fb1-b87b-e9f18ae4d1b9" width="250">|


## 🛠️ Technical Concerns
**ModalManager** 
모달 크기가 작아지면 무조건 키보드가 내려가도록 설정했습니다.  (<- 이 부분에 대해서 피드백 받고싶어요!)
현재 모달 내에서 키보드가 올라온 채로 모달을 내릴 경우, 모달이 키보드 아래로 숨게 되는데, 
이렇게 됐을 때 키보드를 dismiss하는 방법이 없어서, 앱을 껐다 켜야하는 문제가 있습니다. 
그래서 ModalManager에서 `UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)`로 모달이 내려갈 때 키보드도 dismiss 되도록 했는데, 맞는 접근법인지는 잘 모르겠어요.. 의견 부탁드립니다.
