### PR TITLE
[Refactor/#119] 모달 크기 조정에 따른 GoogleMaps 움직임 리팩토링 (scrollBy 메소드 사용하는 방향으로)

### DIFF
--- a/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
+++ b/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 			children = (
 				1371538A2D26CDCA00EABE10 /* Staccato-iOS */,
 				137153892D26CDCA00EABE10 /* Products */,
+				150463252DDC55B30031C30C /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -73,6 +74,15 @@
 				137153882D26CDCA00EABE10 /* Staccato-iOS.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		150463252DDC55B30031C30C /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				79B4A8512DC8E828008CAD72 /* Debug.xcconfig */,
+				79B4A8522DC8E828008CAD72 /* Release.xcconfig */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -170,7 +180,8 @@
 /* Begin XCBuildConfiguration section */
 		137153942D26CDCC00EABE10 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 79B4A8512DC8E828008CAD72 /* Debug.xcconfig */;
+			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
+			baseConfigurationReferenceRelativePath = Support/Config/Debug.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -234,7 +245,8 @@
 		};
 		137153952D26CDCC00EABE10 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 79B4A8522DC8E828008CAD72 /* Release.xcconfig */;
+			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
+			baseConfigurationReferenceRelativePath = Support/Config/Release.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -291,7 +303,8 @@
 		};
 		137153972D26CDCC00EABE10 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 79B4A8512DC8E828008CAD72 /* Debug.xcconfig */;
+			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
+			baseConfigurationReferenceRelativePath = Support/Config/Debug.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -337,7 +350,8 @@
 		};
 		137153982D26CDCC00EABE10 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 79B4A8522DC8E828008CAD72 /* Release.xcconfig */;
+			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
+			baseConfigurationReferenceRelativePath = Support/Config/Release.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -42,7 +42,7 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
         if let cameraPosition = viewModel.cameraPosition {
             moveCamera(on: uiView, to: cameraPosition)
 
-            DispatchQueue.main.async {
+            Task {
                 viewModel.cameraPosition = nil
             }
         }
@@ -178,7 +178,7 @@ private extension GMSMapViewRepresentable {
     /// 카메라 좌표를 이동하며, 모달이 올라온 만큼 지도를 화면 중앙으로 scroll합니다.
     func moveCamera(on mapView: GMSMapView, to cameraPosition: GMSCameraPosition) {
         let deltaY =  (homeModalManager.modalSize.height - ScreenUtils.safeAreaInsets.top) / 2
-        DispatchQueue.main.async {
+        Task {
             mapView.camera = cameraPosition
             mapView.animate(with: GMSCameraUpdate.scrollBy(x: 0, y: deltaY))
         }
@@ -191,7 +191,7 @@ private extension GMSMapViewRepresentable {
         previousSize: HomeModalManager.ModalSize
     ) {
         let deltaY = (currentSize.height - previousSize.height) / 2
-        DispatchQueue.main.async {
+        Task {
             mapView.animate(with: GMSCameraUpdate.scrollBy(x: 0, y: deltaY))
             homeModalManager.previousModalSize = currentSize
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/GMSMapViewRepresentable.swift
@@ -13,6 +13,7 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
 
     @EnvironmentObject var viewModel: HomeViewModel
     @Environment(NavigationState.self) var navigationState
+    @Environment(HomeModalManager.self) var homeModalManager
 
     private let mapView = GMSMapView()
 
@@ -23,10 +24,13 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
         mapView.isMyLocationEnabled = true // 내위치 파란점으로 표시
         mapView.delegate = context.coordinator
         
-        // 초기 위치를 서울시청으로 함
-        let seoulCityhall = CLLocationCoordinate2D(latitude: 37.5664056, longitude: 126.9778222)
-        let camera = GMSCameraPosition.camera(withTarget: seoulCityhall, zoom: 15)
-        mapView.camera = camera
+        // 위치접근권한 없을 경우 초기 위치를 서울시청으로 함
+        if !STLocationManager.shared.hasLocationAuthorization() {
+            let seoulCityhall = CLLocationCoordinate2D(latitude: 37.5665851, longitude: 126.97820379999999)
+            let camera = GMSCameraPosition.camera(withTarget: seoulCityhall, zoom: 15)
+            
+            moveCamera(on: mapView, to: camera)
+        }
 
         return mapView
     }
@@ -34,9 +38,22 @@ struct GMSMapViewRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: GMSMapView, context: Context) {
         updateMarkers(to: uiView)
 
+        // 특정 좌표가 있으면 카메라 이동
         if let cameraPosition = viewModel.cameraPosition {
-            uiView.animate(to: cameraPosition)
+            moveCamera(on: uiView, to: cameraPosition)
+
+            DispatchQueue.main.async {
+                viewModel.cameraPosition = nil
+            }
         }
+
+        // 모달 크기가 조정된 만큼 지도를 scroll
+        let currentSize = homeModalManager.modalSize
+        let previousSize = homeModalManager.previousModalSize
+        if currentSize != previousSize {
+            scrollMap(on: uiView, currentSize: currentSize, previousSize: previousSize)
+        }
+
 #if DEBUG
         print("GMSMapViewRepresentable updated")
 #endif
@@ -74,7 +91,7 @@ extension GMSMapViewRepresentable.Coordinator: CLLocationManagerDelegate {
             return
         }
         let camera = GMSCameraPosition.camera(withTarget: location.coordinate, zoom: 15)
-        parent.mapView.animate(to: camera)
+        parent.moveCamera(on: parent.mapView, to: camera)
     }
 
     // 위치 접근 권한 바뀔 때 파란 점 표시 여부 업데이트 및 현위치로 이동
@@ -84,7 +101,7 @@ extension GMSMapViewRepresentable.Coordinator: CLLocationManagerDelegate {
 
             if let coordinate = manager.location?.coordinate {
                 let camera = GMSCameraPosition.camera(withTarget: coordinate, zoom: 15)
-                parent.mapView.animate(to: camera)
+                parent.moveCamera(on: parent.mapView, to: camera)
             }
         } else {
             parent.mapView.isMyLocationEnabled = false
@@ -114,13 +131,13 @@ extension GMSMapViewRepresentable.Coordinator: GMSMapViewDelegate {
 
 private extension GMSMapViewRepresentable {
 
-    private func updateMarkers(to mapView: GMSMapView) {
+    func updateMarkers(to mapView: GMSMapView) {
         markStaccatos(to: mapView)
         removeMarkers(from: mapView)
     }
 
     /// 지도에 스타카토 마커를 추가합니다.
-    private func markStaccatos(to mapView: GMSMapView) {
+    func markStaccatos(to mapView: GMSMapView) {
         let staccatosToAdd = viewModel.staccatosToAdd
 
         guard !staccatosToAdd.isEmpty else { return }
@@ -147,7 +164,7 @@ private extension GMSMapViewRepresentable {
     }
 
     /// 스타카토 마커를 제거합니다.
-    private func removeMarkers(from mapView: GMSMapView) {
+    func removeMarkers(from mapView: GMSMapView) {
         let staccatosToRemove = viewModel.staccatosToRemove
 
         guard !staccatosToRemove.isEmpty else { return }
@@ -155,6 +172,28 @@ private extension GMSMapViewRepresentable {
         for staccato in staccatosToRemove {
             viewModel.displayedMarkers[staccato.id]?.map = nil
             viewModel.displayedMarkers.removeValue(forKey: staccato.id)
+        }
+    }
+
+    /// 카메라 좌표를 이동하며, 모달이 올라온 만큼 지도를 화면 중앙으로 scroll합니다.
+    func moveCamera(on mapView: GMSMapView, to cameraPosition: GMSCameraPosition) {
+        let deltaY =  (homeModalManager.modalSize.height - ScreenUtils.safeAreaInsets.top) / 2
+        DispatchQueue.main.async {
+            mapView.camera = cameraPosition
+            mapView.animate(with: GMSCameraUpdate.scrollBy(x: 0, y: deltaY))
+        }
+    }
+
+    /// 모달 크기가 조정된 만큼 지도를 scroll합니다.
+    func scrollMap(
+        on mapView: GMSMapView,
+        currentSize: HomeModalManager.ModalSize,
+        previousSize: HomeModalManager.ModalSize
+    ) {
+        let deltaY = (currentSize.height - previousSize.height) / 2
+        DispatchQueue.main.async {
+            mapView.animate(with: GMSCameraUpdate.scrollBy(x: 0, y: deltaY))
+            homeModalManager.previousModalSize = currentSize
         }
     }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -13,27 +13,25 @@ import Kingfisher
 struct HomeView: View {
 
     // MARK: - Properties
+
     //NOTE: View, ViewModel
-    @EnvironmentObject var viewModel: HomeViewModel
-    @EnvironmentObject var mypageViewModel: MyPageViewModel
+    @EnvironmentObject private var viewModel: HomeViewModel
+    @EnvironmentObject private var mypageViewModel: MyPageViewModel
     private let mapView = GMSMapViewRepresentable()
 
-    // NOTE: 모달 크기
-    @Environment(HomeModalManager.self) var homeModalManager
-
-    // NOTE: 화면 전환, Alert 매니저
-    @Environment(NavigationState.self) var navigationState
-    @Environment(StaccatoAlertManager.self) var alertManager
-    @State private var isMyPagePresented = false
-
-    // NOTE: 위치 접근 권한
+    // NOTE: Managers
+    @Environment(HomeModalManager.self) private var homeModalManager
+    @Environment(NavigationState.self) private var navigationState
+    @Environment(StaccatoAlertManager.self) private var alertManager
     @State private var locationAuthorizationManager = STLocationManager.shared
 
-    // NOTE: Staccato Create Modal
-    @State private var isCreateStaccatoModalPresented = false
-
-    // NOTE: 앱 업데이트 Alert 여부
+    // NOTE: UI Visibility
     @State private var showUpdateAlert = false
+    @State private var isMyPagePresented = false
+    @State private var isCreateStaccatoModalPresented = false
+    private var isStaccatoAddButtonVisible: Bool {
+        homeModalManager.modalSize != .large
+    }
 
 
     // MARK: - Body
@@ -51,10 +49,12 @@ struct HomeView: View {
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .topTrailing)
 
-            staccatoAddButton
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-                .padding(.trailing, 12)
-                .padding(.bottom, (homeModalManager.modalHeight - ScreenUtils.safeAreaInsets.bottom) + 12)
+            if isStaccatoAddButtonVisible {
+                staccatoAddButton
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                    .padding(.trailing, 12)
+                    .padding(.bottom, (homeModalManager.modalHeight - ScreenUtils.safeAreaInsets.bottom) + 12)
+            }
 
             categoryListModal
                 .edgesIgnoringSafeArea(.bottom)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -52,9 +52,9 @@ struct HomeView: View {
                 .frame(maxWidth: .infinity, alignment: .topTrailing)
 
             staccatoAddButton
-                .padding(.trailing, 12)
-                .padding(.bottom, homeModalManager.modalHeight - 20)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                .padding(.trailing, 12)
+                .padding(.bottom, (homeModalManager.modalHeight - ScreenUtils.safeAreaInsets.bottom) + 12)
 
             categoryListModal
                 .edgesIgnoringSafeArea(.bottom)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -43,7 +43,6 @@ struct HomeView: View {
             mapView
                 .background(Color.red)
                 .edgesIgnoringSafeArea(.all)
-                .padding(.bottom, homeModalManager.modalHeight - 40)
 
             myPageButton
                 .padding(10)

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/HomeModalManager.swift
@@ -12,8 +12,9 @@ import Observation
 final class HomeModalManager {
 
     var modalHeight: CGFloat = ModalSize.medium.height // 실시간으로 반영되는 사이즈
-    private var modalSize: ModalSize = .medium // 이전으로 되돌리기 위해 기억하는 사이즈
-    
+    var modalSize: ModalSize = .medium // 최신 사이즈
+    var previousModalSize: ModalSize = .medium // 모달 크기가 조정될 때 지도를 scroll할 deltaY를 계산하기 위해 기억하는 사이즈
+
     func updateHeight(to height: CGFloat) {
         modalHeight = height
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #119 

## 🚩 Summary
- `frame(height:)`으로 지도 초점을 조절하던 기존 방식은 키보드가 올라오는 등의 상황에서 레이아웃이 변경될 때 함께 오프셋이 변경되어 지도가 뷰 밖으로 사라지는 등의 문제가 있었습니다. 이에, 지도 크기를 화면 전체로 고정하고, 지도 초점은 GoogleMaps 내장 scrollBy 메소드로 조절하는 방향으로 리팩토링했습니다. 
- 모달이 .large일 때 스타카토 추가 버튼을 숨김처리 했습니다. (QA 반영)
- Config 파일 경로 오류를 해결했습니다. #97 에서 경로가 잘못 조정된 것으로 보입니다.

## 📸 Screenshots
| 스크린샷 1 |
|:--:|
|<img src="https://github.com/user-attachments/assets/dadf39e8-8eb3-4981-b510-1d2879220c06" width="250">|