### PR TITLE
[Fix/#135] 카테고리, 스타카토, 마커 로직 및 UI 오류 해결

### DIFF
--- a/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
+++ b/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 		137153942D26CDCC00EABE10 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
-			baseConfigurationReferenceRelativePath = Support/Debug.xcconfig;
+			baseConfigurationReferenceRelativePath = Support/Config/Debug.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -312,7 +312,7 @@
 		137153972D26CDCC00EABE10 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 1371538A2D26CDCA00EABE10 /* Staccato-iOS */;
-			baseConfigurationReferenceRelativePath = Support/Debug.xcconfig;
+			baseConfigurationReferenceRelativePath = Support/Config/Debug.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Staccato-iOS/Staccato-iOS/Model/Staccato/StaccatoCoordinateModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/Staccato/StaccatoCoordinateModel.swift
@@ -12,9 +12,9 @@ struct StaccatoCoordinateModel: Hashable {
     let id: Int64
 
     let staccatoId: Int64
-    let staccatoColor: String
-    let latitude: Double
-    let longitude: Double
+    var staccatoColor: String
+    var latitude: Double
+    var longitude: Double
 
 }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryDetailView.swift
@@ -55,16 +55,7 @@ struct CategoryDetailView: View {
                 }
                 
                 Button("삭제") {
-                    withAnimation {
-                        alertManager.show(
-                            .confirmCancelAlert(
-                                title: "삭제하시겠습니까?",
-                                message: "삭제를 누르면 복구할 수 없습니다.") {
-                                    viewModel.deleteCategory()
-                                    navigationState.dismiss()
-                                }
-                        )
-                    }
+                    presentDeleteAlert()
                 }
             }
         }
@@ -91,6 +82,7 @@ struct CategoryDetailView: View {
     }
 
 }
+
 
 // MARK: - UI Components
 
@@ -253,4 +245,33 @@ private extension CategoryDetailView {
                 .multilineTextAlignment(.center)
         }
     }
+}
+
+
+// MARK: - Helper
+
+private extension CategoryDetailView {
+
+    func presentDeleteAlert() {
+        withAnimation {
+            alertManager.show(
+                .confirmCancelAlert(
+                    title: "삭제하시겠습니까?",
+                    message: "삭제를 누르면 복구할 수 없습니다."
+                ) {
+                    Task {
+                        let success = await viewModel.deleteCategory()
+                        if success {
+                            navigationState.dismiss()
+                            
+                            if let staccatoIds = viewModel.categoryDetail?.staccatos.map(\.staccatoId) {
+                                homeViewModel.removeStaccatos(with: Set(staccatoIds))
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -70,9 +70,9 @@ struct CategoryEditorView: View {
                             await vm.modifyCategory()
                             
                             // 마커 업데이트
-                            if let staccatos = vm.categoryDetail?.staccatos {
+                            if let staccatoIds = vm.categoryDetail?.staccatos.map({ $0.staccatoId }) {
                                 homeViewModel.updateMarkerIcons(
-                                    for: staccatos.map { $0.staccatoId },
+                                    for: staccatoIds,
                                     to: vm.categoryColor
                                 )
                             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -10,6 +10,8 @@ import PhotosUI
 
 struct CategoryEditorView: View {
     @Environment(\.dismiss) var dismiss
+    @Environment(NavigationState.self) private var navigationState
+
     @Bindable private var vm: CategoryEditorViewModel
 
     @FocusState private var isTitleFocused: Bool
@@ -60,7 +62,9 @@ struct CategoryEditorView: View {
                     Task {
                         switch vm.editorType {
                         case .create:
-                            await vm.createCategory()
+                            if let categoryId: Int64 = await vm.createCategory() {
+                                navigationState.navigate(to: .categoryDetail(categoryId))
+                            }
                         case .modify:
                             await vm.modifyCategory()
                         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -11,6 +11,7 @@ import PhotosUI
 struct CategoryEditorView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(NavigationState.self) private var navigationState
+    @EnvironmentObject var homeViewModel: HomeViewModel
 
     @Bindable private var vm: CategoryEditorViewModel
 
@@ -67,6 +68,14 @@ struct CategoryEditorView: View {
                             }
                         case .modify:
                             await vm.modifyCategory()
+                            
+                            // 마커 업데이트
+                            if let staccatos = vm.categoryDetail?.staccatos {
+                                homeViewModel.updateMarkerIcons(
+                                    for: staccatos.map { $0.staccatoId },
+                                    to: vm.categoryColor
+                                )
+                            }
                         }
                     }
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryListView.swift
@@ -62,12 +62,15 @@ struct CategoryListView: View {
         }
 
         .onAppear {
-            do {
-                try viewModel.getCategoryList()
-            } catch {
-                // 여기서 에러 메세지 띄우는 동작 등 구현
-                print(error.localizedDescription)
-            }
+            fetchCategoryList()
+        }
+
+        .onChange(of: viewModel.filterSelection) {
+            fetchCategoryList()
+        }
+
+        .onChange(of: viewModel.sortSelection) {
+            fetchCategoryList()
         }
 
         .fullScreenCover(isPresented: $isCreateCategoryModalPresented) {
@@ -190,6 +193,23 @@ private extension CategoryListView {
                         Divider()
                     }
                 }
+            }
+        }
+    }
+
+}
+
+
+// MARK: - Helper
+
+private extension CategoryListView {
+
+    func fetchCategoryList() {
+        Task {
+            do {
+                try await viewModel.getCategoryList()
+            } catch {
+                print("❌ Error: \(error.localizedDescription)")
             }
         }
     }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -178,6 +178,7 @@ private extension HomeView {
                     .foregroundStyle(.gray2)
 
                 CategoryListView(navigationState)
+                    .padding(.top, 21)
             }
             .background(Color.staccatoWhite)
             .frame(maxHeight: homeModalManager.modalHeight)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -51,7 +51,8 @@ struct StaccatoEditorView: View {
             }
         }
         .onAppear {
-            if STLocationManager.shared.hasLocationAuthorization() {
+            if viewModel.editorMode == .create,
+               STLocationManager.shared.hasLocationAuthorization() {
                 STLocationManager.shared.getCurrentPlaceInfo { place in
                     self.viewModel.selectedPlace = place
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -383,7 +383,11 @@ extension StaccatoEditorView {
                     homeViewModel.fetchStaccatos()
                 case .modify(let id):
                     await viewModel.modifyStaccato(staccatoId: id)
-                    homeViewModel.fetchStaccatos()
+
+                    // 마커 좌표 업데이트
+                    if let newCoordinate = viewModel.selectedPlace?.coordinate {
+                        homeViewModel.updateMarkersPosition(for: id, to: newCoordinate)
+                    }
                 }
             }
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
@@ -111,7 +111,7 @@ final class CategoryEditorViewModel {
         }
     }
 
-    func createCategory() async {
+    func createCategory() async -> Int64? {
         let body = PostCategoryRequest(
             categoryThumbnailUrl: self.imageURL,
             categoryTitle: self.categoryTitle,
@@ -123,12 +123,14 @@ final class CategoryEditorViewModel {
         )
 
         do {
-            try await STService.shared.categoryService.postCategory(body)
+            let response = try await STService.shared.categoryService.postCategory(body)
             try await categoryViewModel.getCategoryList()
             self.uploadSuccess = true
+            return response.categoryId
         } catch {
             errorMessage = error.localizedDescription
             catchError = true
+            return nil
         }
     }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
@@ -12,6 +12,9 @@ import PhotosUI
 @Observable
 final class CategoryEditorViewModel {
 
+    // MARK: - CategoryDetail
+    let categoryDetail: CategoryDetailModel?
+
     // MARK: - Photo Related
     var isPhotoInputPresented = false
     var isPhotoPickerPresented = false
@@ -56,6 +59,8 @@ final class CategoryEditorViewModel {
         editorType: CategoryEditorType = .create,
         categoryViewModel: CategoryViewModel
     ) {
+        self.categoryDetail = categoryDetail
+
         self.id = categoryDetail?.categoryId
         self.categoryViewModel = categoryViewModel
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
@@ -72,6 +72,10 @@ final class CategoryEditorViewModel {
         self.categoryDescription = categoryDetail?.description ?? ""
         self.categoryTitle = categoryDetail?.categoryTitle ?? ""
 
+        if let categoryColor = categoryDetail?.categoryColor {
+            self.categoryColor = CategoryColorType.fromServerKey(categoryColor) ?? .gray
+        }
+
         if let startAt = categoryDetail?.startAt,
            let endAt = categoryDetail?.endAt {
             self.selectedStartDate = Date.fromString(startAt)

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryViewModel.swift
@@ -67,18 +67,19 @@ final class CategoryViewModel: ObservableObject {
         }
     }
 
-    func deleteCategory() {
+    func deleteCategory() async -> Bool {
         guard let categoryDetail else {
             print("⚠️ \(StaccatoError.optionalBindingFailed) - delete category")
-            return
+            return false
         }
-        Task {
-            do {
-                try await STService.shared.categoryService.deleteCategory(categoryDetail.categoryId)
-                try getCategoryList()
-            } catch {
-                print("⚠️ \(error.localizedDescription) - delete category")
-            }
+
+        do {
+            try await STService.shared.categoryService.deleteCategory(categoryDetail.categoryId)
+            try getCategoryList()
+            return true
+        } catch {
+            print("⚠️ \(error.localizedDescription) - delete category")
+            return false
         }
     }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryViewModel.swift
@@ -14,44 +14,25 @@ final class CategoryViewModel: ObservableObject {
 
     @Published var categories: [CategoryModel] = []
 
-    @Published var filterSelection: CategoryListFilterType = .all {
-        didSet {
-            do {
-                try getCategoryList()
-            } catch {
-                print("❌ error: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    @Published var sortSelection: CategoryListSortType = .recentlyUpdated {
-        didSet {
-            do {
-                try getCategoryList()
-            } catch {
-                print("❌ error: \(error.localizedDescription)")
-            }
-        }
-    }
+    @Published var filterSelection: CategoryListFilterType = .all
+    @Published var sortSelection: CategoryListSortType = .recentlyUpdated
 
     @Published var categoryDetail: CategoryDetailModel?
 
 
     // MARK: - Networking
 
-    func getCategoryList() throws {
-        Task {
-            let categoryList = try await STService.shared.categoryService.getCategoryList(
-                GetCategoryListRequestQuery(
-                    filters: filterSelection.serverKey,
-                    sort: sortSelection.serverKey
-                )
+    func getCategoryList() async throws {
+        let categoryList = try await STService.shared.categoryService.getCategoryList(
+            GetCategoryListRequestQuery(
+                filters: filterSelection.serverKey,
+                sort: sortSelection.serverKey
             )
-            
-            let categories = categoryList.categories.map { CategoryModel(from: $0) }
-            withAnimation {
-                self.categories = categories
-            }
+        )
+        
+        let categories = categoryList.categories.map { CategoryModel(from: $0) }
+        withAnimation {
+            self.categories = categories
         }
     }
 
@@ -75,7 +56,7 @@ final class CategoryViewModel: ObservableObject {
 
         do {
             try await STService.shared.categoryService.deleteCategory(categoryDetail.categoryId)
-            try getCategoryList()
+            try await getCategoryList()
             return true
         } catch {
             print("⚠️ \(error.localizedDescription) - delete category")

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
@@ -77,15 +77,47 @@ extension HomeViewModel {
 
 extension HomeViewModel {
 
-    /// Updates marker icons for the given list of staccatos
+    /// 마커 아이콘 업데이트
     func updateMarkerIcons(for staccatoIds: [Int64], to colorType: CategoryColorType) {
         for staccatoId in staccatoIds {
             guard let marker = displayedMarkers[staccatoId] else {
                 print("⚠️ Marker not found for staccato ID: \(staccatoId)")
                 continue
             }
+
             marker.icon = colorType.markerImage
+            updateMarkerUserData(marker, newColor: colorType.serverKey)
         }
+    }
+
+    /// 마커 위치 업데이트
+    func updateMarkersPosition(for staccatoId: Int64, to coordinate: CLLocationCoordinate2D) {
+        guard let marker = displayedMarkers[staccatoId] else {
+            print("⚠️ Marker not found for staccato ID: \(staccatoId)")
+            return
+        }
+
+        marker.position = coordinate
+        updateMarkerUserData(marker, newCoordinate: coordinate)
+    }
+
+    private func updateMarkerUserData(
+        _ marker: GMSMarker,
+        newColor: String? = nil,
+        newCoordinate: CLLocationCoordinate2D? = nil
+    ) {
+        var userData = marker.userData as? StaccatoCoordinateModel
+
+        if let newColor = newColor {
+            userData?.staccatoColor = newColor
+        }
+
+        if let newCoordinate = newCoordinate {
+            userData?.latitude = newCoordinate.latitude
+            userData?.longitude = newCoordinate.longitude
+        }
+
+        marker.userData = userData
     }
 
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
@@ -63,11 +63,29 @@ extension HomeViewModel {
 // MARK: - Map
 
 extension HomeViewModel {
-    
+
     func moveCamera(to coordinate: CLLocationCoordinate2D, zoom: Float = 15.0) {
         withAnimation {
             cameraPosition = GMSCameraPosition.camera(withTarget: coordinate, zoom: 15)
         }
     }
-    
+
+}
+
+
+// MARK: - Marker Updates
+
+extension HomeViewModel {
+
+    /// Updates marker icons for the given list of staccatos
+    func updateMarkerIcons(for staccatoIds: [Int64], to colorType: CategoryColorType) {
+        for staccatoId in staccatoIds {
+            guard let marker = displayedMarkers[staccatoId] else {
+                print("⚠️ Marker not found for staccato ID: \(staccatoId)")
+                continue
+            }
+            marker.icon = colorType.markerImage
+        }
+    }
+
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Home/HomeViewModel.swift
@@ -29,6 +29,11 @@ class HomeViewModel: ObservableObject {
 
     @Published var cameraPosition: GMSCameraPosition?
 
+    
+    func removeStaccatos(with staccatoIds: Set<Int64>) {
+        staccatos = staccatos.filter { !staccatoIds.contains($0.staccatoId) }
+    }
+
 }
 
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
@@ -43,6 +43,7 @@ class StaccatoEditorViewModel {
 
     var uploadSuccess = false
 
+    /// Create Staccato
     init(selectedCategory: CategoryModel? = nil) {
         self.editorMode = .create
         self.selectedCategory = selectedCategory
@@ -50,6 +51,7 @@ class StaccatoEditorViewModel {
         getCategoryList()
     }
 
+    /// Modify Staccato
     init(staccato: StaccatoDetailModel) {
         self.editorMode = .modify(id: staccato.staccatoId)
         getPhotos(urls: staccato.staccatoImageUrls)

--- a/Staccato-iOS/Staccato-iOS/Service/Category/CategoryService.swift
+++ b/Staccato-iOS/Staccato-iOS/Service/Category/CategoryService.swift
@@ -43,7 +43,6 @@ class CategoryService: CategoryServiceProtocol {
         return categoryDetail
     }
 
-    @discardableResult
     func postCategory(_ requestBody: PostCategoryRequest) async throws -> PostCategoryResponse {
         guard let categoryId = try await NetworkService.shared.request(
             endpoint: CategoryEndpoint.postCategory(requestBody),

--- a/Staccato-iOS/Staccato-iOS/Service/Category/DTO/PostCategoryResponse.swift
+++ b/Staccato-iOS/Staccato-iOS/Service/Category/DTO/PostCategoryResponse.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct PostCategoryResponse: Decodable {
-    let categoryId: Int
+    let categoryId: Int64
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #135 

## 🚩 Summary

구현이 안 되어있던 로직을 구현하고 오류를 해결했습니다.
- 카테고리
  - 카테고리 생성 후 카테고리 상세로 이동
  - 카테고리 수정 시 컬러 데이터 바인딩
  - 카테고리 리스트 조회 비동기 로직 개선
- 스타카토
  - 스타카토 수정 시 장소 데이터 바인딩 안 되는 문제 해결
- 마커
  - 카테고리 수정 후 마커 아이콘 업데이트 (ex. 노랑 -> 파랑)
  - 스타카토 수정 후 마커 좌표 업데이트
  - 카테고리 삭제 후 마커 일괄 삭제

## 📸 Screenshots
| 카테고리 및 스타카토 생성 | 카테고리 수정 후 마커 업데이트 | 스타카토 수정 후 마커 업데이트 | 카테고리 삭제 후 마커 일괄삭제 |
|:--:|:--:|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/196c6572-5d98-4b1b-907f-a20a1d3ecabf" width="250">|<img src="https://github.com/user-attachments/assets/08059fbf-9140-427b-8fee-0afdf46c82af" width="250">| <img src="https://github.com/user-attachments/assets/8deff719-63b4-4151-b42f-ad53fa913dc5" width="250">|<img src="https://github.com/user-attachments/assets/11fbe709-c84b-491c-9d02-f949b9e9fca6" width="250">|


## 🙂 To Reviewer
스타카토 생성/삭제 후에 카테고리 리스트 UI 업데이트가 안 되는 문제를 발견했는데 여유가 없어서 고치지 못했습니다 🥲 