### PR TITLE
[Fix/#150] Google Map API 연속 호출 수정

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Home/HomeView.swift
@@ -57,7 +57,7 @@ struct HomeView: View {
                         y: calculateFloatingButtonY(in: geometry)
                     )
                     .animation(.spring(response: 0.4, dampingFraction: 0.8),
-                               value: detentManager.currentHeight)
+                               value: detentManager.currentDetent.height)
                 
                 if alertManager.isPresented {
                     StaccatoAlertView()
@@ -192,11 +192,11 @@ private extension HomeView {
         let safeAreaBottom = geometry.safeAreaInsets.bottom
         let defaultY = geometry.size.height - safeAreaBottom - 12
         
-        guard detentManager.isbottomSheetPresented && detentManager.currentHeight > 0 else {
+        guard detentManager.isbottomSheetPresented && detentManager.currentDetent.height > 0 else {
             return defaultY
         }
         
-        let sheetTopY = geometry.size.height - detentManager.currentHeight - safeAreaBottom
+        let sheetTopY = geometry.size.height - detentManager.currentDetent.height - safeAreaBottom
         let buttonOffset: CGFloat = 12
         
         return max(sheetTopY - buttonOffset, 100)

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
@@ -27,23 +27,21 @@ enum BottomSheetDetent: CaseIterable {
 @MainActor
 final class BottomSheetDetentManager: ObservableObject {
 
-    @Published var currentHeight: CGFloat = BottomSheetDetent.medium.height // 상세한 높이
     @Published var currentDetent: BottomSheetDetent = .medium
     @Published var previousDetent: BottomSheetDetent = .medium
     @Published var isbottomSheetPresented: Bool = true
     @Published var selectedDetent: PresentationDetent = BottomSheetDetent.medium.detent
     
     func updateDetent(_ newHeight: CGFloat) {
-        currentHeight = newHeight
-        
-        if let detectedDetent = detectDetent(from: newHeight) {
+        if let detectedDetent = detectDetent(from: newHeight), currentDetent != detectedDetent {
             currentDetent = detectedDetent
         }
     }
     
     func updateDetent(to size: BottomSheetDetent) {
-        currentDetent = size
-        currentHeight = currentDetent.height
+        if currentDetent != size {
+            currentDetent = size
+        }
     }
     
     private func detectDetent(from height: CGFloat) -> BottomSheetDetent? {


### PR DESCRIPTION
## ⭐️ Issue Number
- #150 

## 🚩 Summary
- Google Map API 연속 호출 수정

## 📸 Screenshots

https://github.com/user-attachments/assets/77b410e4-48cc-4d80-afce-e3520cccf679

## 🛠️ Technical Concerns

### BottomSheetDetentManager 바인딩

해당 문제는 BottomSheetDetentManager를 홈화면과 지도 뷰 모두에서 공유하며 사용하여 발생한 문제였습니다.
홈 화면에 스타카토 추가 플로팅 버튼이 sheet를 따라다니면 더 좋은 UI일 것 같다는 생각으로 `currentHeight`라는 Published 프로퍼티를 생성하고 시트의 높이가 변화할때마다 해당 프로퍼티가 시트의 높이를 계속해서 옵저빙하고 있었습니다.

```swift
final class BottomSheetDetentManager: ObservableObject {
    @Published var currentHeight: CGFloat
    ...
}
```

이때, `GMSMapViewRepresentable` 또한 홈과 동일한 `BottomSheetDetentManager` 객체를 가지고 있었고, 내부적으로 바인딩이 되어있어, 홈과 공유되는 `BottomSheetDetentManager` 내부 프로퍼티 값이 하나라도 바뀔 경우 `updateUIView`가 호출되게 됩니다.

일단 빠르게 해당 이슈를 수정하기 위해 플로팅 버튼이 sheet를 계속해서 따라가지는 않고 기존의 방식과 동일하게 detent 값이 정확해지는 경우에만 버튼의 위치가 바뀌도록 수정했습니다.