### PR TITLE
[Feat/#166] 2.0.0 기능 QA 적용

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -83,7 +83,7 @@ struct CategoryEditorView: View {
                     }
                 }
                 .buttonStyle(.staccatoFullWidth)
-                .disabled(viewModel.isSubmitButtonDisabled)
+                .disabled(viewModel.isSubmitButtonDisabled || viewModel.isSaving)
             }
             .animation(.easeIn(duration: 0.15), value: viewModel.isPeriodSettingActive)
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -9,14 +9,15 @@ import SwiftUI
 import PhotosUI
 
 struct CategoryEditorView: View {
+    
     @Environment(\.dismiss) var dismiss
+    @Environment(\.openURL) var openURL
     @Environment(NavigationState.self) private var navigationState
     @EnvironmentObject var homeViewModel: HomeViewModel
 
     @State private var viewModel: CategoryEditorViewModel
-
+    @State private var showSettingAlert: Bool = false
     @FocusState private var isTitleFocused: Bool
-
     @FocusState private var isDescriptionFocused: Bool
 
     init(
@@ -150,7 +151,13 @@ extension CategoryEditorView {
 
         .confirmationDialog("사진을 첨부해 보세요", isPresented: $viewModel.isPhotoInputPresented, titleVisibility: .visible, actions: {
             Button("카메라 열기") {
-                viewModel.showCamera = true
+                CameraView.checkCameraPermission { granted in
+                    if granted {
+                        viewModel.showCamera = granted
+                    } else {
+                        showSettingAlert = true
+                    }
+                }
             }
 
             Button("앨범에서 가져오기") {
@@ -167,6 +174,17 @@ extension CategoryEditorView {
         } content: {
             CameraView(selectedImage: $viewModel.selectedPhoto)
                 .background(.staccatoBlack)
+        }
+        
+        .alert(isPresented: $showSettingAlert) {
+            Alert(
+                title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
+                message: Text("설정 > {앱 이름} 탭에서 접근을 활성화 할 수 있습니다."),
+                primaryButton: .default(Text("설정으로 이동"), action: {
+                    openURL(URL(string: UIApplication.openSettingsURLString)!)
+                }),
+                secondaryButton: .cancel(Text("취소"))
+            )
         }
     }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -181,7 +181,7 @@ extension CategoryEditorView {
         .alert(isPresented: $showSettingAlert) {
             Alert(
                 title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
-                message: Text("설정 > {앱 이름} 탭에서 접근을 활성화 할 수 있습니다."),
+                message: Text("설정에서 카메라 접근을 활성화 해주세요."),
                 primaryButton: .default(Text("설정으로 이동"), action: {
                     openURL(URL(string: UIApplication.openSettingsURLString)!)
                 }),

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -183,7 +183,9 @@ extension CategoryEditorView {
                 title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
                 message: Text("설정에서 카메라 접근을 활성화 해주세요."),
                 primaryButton: .default(Text("설정으로 이동"), action: {
-                    openURL(URL(string: UIApplication.openSettingsURLString)!)
+                    if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingURL)
+                    }
                 }),
                 secondaryButton: .cancel(Text("취소"))
             )

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/CategoryEditorView.swift
@@ -64,11 +64,13 @@ struct CategoryEditorView: View {
                     Task {
                         switch viewModel.editorType {
                         case .create:
-                            if let categoryId: Int64 = await viewModel.createCategory() {
+                            await viewModel.saveCategory(.create) { categoryId in
+                                guard let categoryId else { return }
+                                
                                 navigationState.navigate(to: .categoryDetail(categoryId))
                             }
                         case .modify:
-                            await viewModel.modifyCategory()
+                            await viewModel.saveCategory(.modify)
                             
                             // 마커 업데이트
                             if let staccatoIds = viewModel.categoryDetail?.staccatos.map({ $0.staccatoId }) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/InvitationMemberView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/InvitationMemberView.swift
@@ -28,12 +28,12 @@ struct InvitationMemberView: View {
             
             searchBarView
                 .padding(.top, 20)
-                .padding([.leading, .trailing], 16)
+                .padding(.horizontal, 16)
                 .presentationCornerRadius(5)
             
             if !viewModel.selectedMembers.isEmpty {
                 selectedListView
-                    .padding([.top, .leading], 16)
+                    .padding([.top, .horizontal], 16)
                 
                 Divider()
                     .padding(.top, 15)

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Category/InvitationMemberView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Category/InvitationMemberView.swift
@@ -21,7 +21,7 @@ struct InvitationMemberView: View {
     }
     
     var body: some View {
-        VStack(alignment: .center) {
+        VStack(alignment: .center, spacing: 0) {
             titleBarView
                 .padding(.leading, 16)
                 .padding([.top, .trailing], 18)
@@ -31,24 +31,19 @@ struct InvitationMemberView: View {
                 .padding([.leading, .trailing], 16)
                 .presentationCornerRadius(5)
             
-            if viewModel.selectedMembers.isEmpty && viewModel.searchMembers.isEmpty {
-                staccatoEmptyView
-                .padding(.top, 111)
+            if !viewModel.selectedMembers.isEmpty {
+                selectedListView
+                    .padding([.top, .leading], 16)
+                
+                Divider()
+                    .padding(.top, 15)
+            }
+            
+            if !viewModel.searchMembers.isEmpty {
+                searchListView
             } else {
-                Group {
-                    if !viewModel.selectedMembers.isEmpty {
-                        selectedListView
-                            .padding([.top, .leading], 16)
-                    }
-                    
-                    if !viewModel.searchMembers.isEmpty {
-                        searchListView
-                            .padding(.top, 17)
-                    } else {
-                        staccatoEmptyView
-                            .padding(.top, 111)
-                    }
-                }
+                staccatoEmptyView
+                    .padding(.top, viewModel.selectedMembers.isEmpty ? 111 : 80)
             }
             
             Spacer()
@@ -177,12 +172,12 @@ private extension InvitationMemberView {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.searchMembers) { member in
-                    Divider()
-                    
                     SearchMemberRow(member: member) { member in
                         viewModel.toggleMemberSelection(member)
                     }
                     .frame(height: 60)
+                    
+                    Divider()
                 }
             }
         }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
@@ -110,7 +110,7 @@ extension MyPageView {
         .alert(isPresented: $showSettingAlert) {
             Alert(
                 title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
-                message: Text("설정 > {앱 이름} 탭에서 접근을 활성화 할 수 있습니다."),
+                message: Text("설정에서 카메라 접근을 활성화 해주세요."),
                 primaryButton: .default(Text("설정으로 이동"), action: {
                     openURL(URL(string: UIApplication.openSettingsURLString)!)
                 }),

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/MyPage/MyPageView.swift
@@ -112,7 +112,9 @@ extension MyPageView {
                 title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
                 message: Text("설정에서 카메라 접근을 활성화 해주세요."),
                 primaryButton: .default(Text("설정으로 이동"), action: {
-                    openURL(URL(string: UIApplication.openSettingsURLString)!)
+                    if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingURL)
+                    }
                 }),
                 secondaryButton: .cancel(Text("취소"))
             )

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/CameraView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/CameraView.swift
@@ -6,9 +6,16 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 struct CameraView: UIViewControllerRepresentable {
-    let cameraMode: CameraMode
+    
+    enum CameraMode {
+        case single
+        case multiple
+    }
+    
+    private let cameraMode: CameraMode
     @Binding var selectedImage: UIImage?
     @Binding var imageList: [UploadablePhoto]
     @Environment(\.presentationMode) var isPresented
@@ -63,9 +70,20 @@ struct CameraView: UIViewControllerRepresentable {
             self.picker.isPresented.wrappedValue.dismiss()
         }
     }
+}
 
-    enum CameraMode {
-        case single
-        case multiple
+extension CameraView {
+    static func checkCameraPermission(completion: @escaping (Bool) -> Void) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: completion(true)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                Task { @MainActor in
+                    completion(granted)
+                }
+            }
+        case .denied, .restricted: completion(false)
+        @unknown default: completion(false)
+        }
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -392,7 +392,7 @@ extension StaccatoEditorView {
             }
         }
         .buttonStyle(.staccatoFullWidth)
-        .disabled(!viewModel.isReadyToSave)
+        .disabled(!viewModel.isReadyToSave || viewModel.isSaving)
     }
 
     // MARK: - Components

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -56,10 +56,10 @@ struct StaccatoEditorView: View {
 
                 saveButton
             }
+            .padding(.horizontal, 24)
         }
         .dismissKeyboardOnGesture()
         .scrollIndicators(.hidden)
-        .padding(.horizontal, 24)
 
         .onAppear {
             if viewModel.editorMode == .create,

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -99,6 +99,17 @@ struct StaccatoEditorView: View {
                   message: nil,
                   dismissButton: .default(Text("확인")) { isPhotoFull = false })
         }
+        
+        .alert(isPresented: $showSettingAlert) {
+            Alert(
+                title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
+                message: Text("설정에서 카메라 접근을 활성화 해주세요."),
+                primaryButton: .default(Text("설정으로 이동"), action: {
+                    openURL(URL(string: UIApplication.openSettingsURLString)!)
+                }),
+                secondaryButton: .cancel(Text("취소"))
+            )
+        }
 
         .alert("위치 권한 필요", isPresented: $showLocationAlert) {
             Button("설정 열기") {
@@ -109,7 +120,6 @@ struct StaccatoEditorView: View {
             Text("Staccato 사용을 위해 설정에서 위치 접근 권한을 허용해주세요.")
         }
     }
-
 }
 
 extension StaccatoEditorView {
@@ -165,17 +175,6 @@ extension StaccatoEditorView {
         .fullScreenCover(isPresented: $viewModel.showCamera) {
             CameraView(cameraMode: .multiple, imageList: self.$viewModel.photos)
                 .background(.black)
-        }
-        
-        .alert(isPresented: $showSettingAlert) {
-            Alert(
-                title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
-                message: Text("설정 > {앱 이름} 탭에서 접근을 활성화 할 수 있습니다."),
-                primaryButton: .default(Text("설정으로 이동"), action: {
-                    openURL(URL(string: UIApplication.openSettingsURLString)!)
-                }),
-                secondaryButton: .cancel(Text("취소"))
-            )
         }
         
         .onChange(of: viewModel.uploadSuccess, { _, uploadSuccess in

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -380,10 +380,10 @@ extension StaccatoEditorView {
             Task {
                 switch viewModel.editorMode {
                 case .create:
-                    await viewModel.createStaccato()
+                    await viewModel.saveStaccato(.create)
                     homeViewModel.fetchStaccatos()
                 case .modify(let id):
-                    await viewModel.modifyStaccato(staccatoId: id)
+                    await viewModel.saveStaccato(.modify(id: id))
 
                     // 마커 좌표 업데이트
                     if let newCoordinate = viewModel.selectedPlace?.coordinate {

--- a/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/View/Staccato/StaccatoEditorView.swift
@@ -105,7 +105,9 @@ struct StaccatoEditorView: View {
                 title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
                 message: Text("설정에서 카메라 접근을 활성화 해주세요."),
                 primaryButton: .default(Text("설정으로 이동"), action: {
-                    openURL(URL(string: UIApplication.openSettingsURLString)!)
+                    if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(settingURL)
+                    }
                 }),
                 secondaryButton: .cancel(Text("취소"))
             )

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
@@ -11,6 +11,12 @@ import PhotosUI
 
 @Observable
 final class CategoryEditorViewModel {
+    
+    // MARK: - Editor Type
+    enum CategoryEditorType {
+        case modify
+        case create
+    }
 
     // MARK: - CategoryDetail
     let categoryDetail: CategoryDetailModel?
@@ -53,6 +59,9 @@ final class CategoryEditorViewModel {
     var id: Int64?
     var editorType: CategoryEditorType = .create
     private let categoryViewModel: CategoryViewModel
+    
+    private var lastAPICallTime: Date = .distantPast
+    private let throttleInterval: TimeInterval = 2.0
 
     init(
         categoryDetail: CategoryDetailModel? = nil,
@@ -106,7 +115,6 @@ final class CategoryEditorViewModel {
     }
 
     func uploadImage() async throws {
-       
         do {
             let requestBody = PostImageRequest(image: selectedPhoto)
             let imageUrl = try await STService.shared.imageService.uploadImage(requestBody)
@@ -116,8 +124,46 @@ final class CategoryEditorViewModel {
             catchError = true
         }
     }
+    
+    func getImage(_ url: String) {
+        Task {
+            guard let url = URL(string: url) else {
+                self.selectedPhoto = nil
+                return
+            }
 
-    func createCategory() async -> Int64? {
+            let loadedImage = await Task {
+                do {
+                    let (data, _) = try await URLSession.shared.data(from: url)
+                    return UIImage(data: data)
+                } catch {
+                    print("이미지 다운로드 실패: \(error)")
+                    return nil
+                }
+            }
+            .value
+
+            self.selectedPhoto = loadedImage
+        }
+    }
+
+    func saveCategory(_ type: CategoryEditorType, completion: ((Int64?) -> Void)? = nil) async {
+        let now = Date()
+        let timeSinceLastCall = now.timeIntervalSince(lastAPICallTime)
+        
+        guard timeSinceLastCall >= throttleInterval else { return }
+        
+        lastAPICallTime = now
+        
+        switch type {
+        case .create:
+            await completion?(createCategory())
+        case .modify:
+            await modifyCategory()
+        }
+    }
+    
+    private func createCategory() async -> Int64? {
         let startAt: String? = isPeriodSettingActive ? selectedStartDate?.formattedAsRequestDate : nil
         let endAt: String? = isPeriodSettingActive ? selectedEndDate?.formattedAsRequestDate : nil
         
@@ -143,7 +189,7 @@ final class CategoryEditorViewModel {
         }
     }
 
-    func modifyCategory() async {
+    private func modifyCategory() async {
         let startAt: String? = isPeriodSettingActive ? selectedStartDate?.formattedAsRequestDate : nil
         let endAt: String? = isPeriodSettingActive ? selectedEndDate?.formattedAsRequestDate : nil
 
@@ -168,34 +214,4 @@ final class CategoryEditorViewModel {
             catchError = true
         }
     }
-
-    func getImage(_ url: String) {
-        Task {
-            guard let url = URL(string: url) else {
-                self.selectedPhoto = nil
-                return
-            }
-
-            let loadedImage = await Task {
-                do {
-                    let (data, _) = try await URLSession.shared.data(from: url)
-                    return UIImage(data: data)
-                } catch {
-                    print("이미지 다운로드 실패: \(error)")
-                    return nil
-                }
-            }
-            .value
-
-            self.selectedPhoto = loadedImage
-        }
-    }
-
-
-    // MARK: - Editor Type
-    enum CategoryEditorType {
-        case modify
-        case create
-    }
-
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/CategoryEditorViewModel.swift
@@ -60,6 +60,7 @@ final class CategoryEditorViewModel {
     var editorType: CategoryEditorType = .create
     private let categoryViewModel: CategoryViewModel
     
+    var isSaving = false
     private var lastAPICallTime: Date = .distantPast
     private let throttleInterval: TimeInterval = 2.0
 
@@ -148,6 +149,8 @@ final class CategoryEditorViewModel {
     }
 
     func saveCategory(_ type: CategoryEditorType, completion: ((Int64?) -> Void)? = nil) async {
+        guard !isSaving else { return }
+        
         let now = Date()
         let timeSinceLastCall = now.timeIntervalSince(lastAPICallTime)
         
@@ -164,6 +167,8 @@ final class CategoryEditorViewModel {
     }
     
     private func createCategory() async -> Int64? {
+        isSaving = true
+        
         let startAt: String? = isPeriodSettingActive ? selectedStartDate?.formattedAsRequestDate : nil
         let endAt: String? = isPeriodSettingActive ? selectedEndDate?.formattedAsRequestDate : nil
         
@@ -181,15 +186,19 @@ final class CategoryEditorViewModel {
             let response = try await STService.shared.categoryService.postCategory(body)
             try await categoryViewModel.getCategoryList()
             self.uploadSuccess = true
+            isSaving = false
             return response.categoryId
         } catch {
             errorMessage = error.localizedDescription
             catchError = true
+            isSaving = false
             return nil
         }
     }
 
     private func modifyCategory() async {
+        isSaving = true
+        
         let startAt: String? = isPeriodSettingActive ? selectedStartDate?.formattedAsRequestDate : nil
         let endAt: String? = isPeriodSettingActive ? selectedEndDate?.formattedAsRequestDate : nil
 
@@ -213,5 +222,7 @@ final class CategoryEditorViewModel {
             errorMessage = error.localizedDescription
             catchError = true
         }
+        
+        isSaving = false
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/InvitationMemberViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Category/InvitationMemberViewModel.swift
@@ -56,7 +56,14 @@ final class InvitationMemberViewModel {
     private func bind() {
         nameSubject
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
-            .sink { self.getSearchedMember($0) }
+            .removeDuplicates()
+            .sink { [weak self] searchText in
+                if searchText.isEmpty {
+                    self?.searchMembers = []
+                } else {
+                    self?.getSearchedMember(searchText)
+                }
+            }
             .store(in: &cancellables)
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
@@ -12,8 +12,8 @@ import PhotosUI
 final class StaccatoEditorViewModel {
 
     enum StaccatoEditorMode: Equatable {
-        case modify(id: Int64)
         case create
+        case modify(id: Int64)
     }
 
     let editorMode: StaccatoEditorMode
@@ -51,6 +51,9 @@ final class StaccatoEditorViewModel {
     var selectedCategory: CategoryCandidateModel?
 
     var uploadSuccess = false
+    
+    private var lastAPICallTime: Date = .distantPast
+    private let throttleInterval: TimeInterval = 2.0
 
     /// Create Staccato
     init(selectedCategory: CategoryCandidateModel? = nil) {
@@ -132,7 +135,24 @@ final class StaccatoEditorViewModel {
 // MARK: - Network
 
 extension StaccatoEditorViewModel {
-    func createStaccato() async {
+    
+    func saveStaccato(_ type: StaccatoEditorMode) async {
+        let now = Date()
+        let timeSinceLastCall = now.timeIntervalSince(lastAPICallTime)
+        
+        guard timeSinceLastCall >= throttleInterval else { return }
+        
+        lastAPICallTime = now
+        
+        switch type {
+        case .create:
+            await createStaccato()
+        case .modify(let staccatoId):
+            await modifyStaccato(staccatoId: staccatoId)
+        }
+    }
+    
+    private func createStaccato() async {
         guard let selectedCategoryId = self.selectedCategory?.categoryId else {
             self.catchError = true
             self.errorMessage = "유효한 카테고리를 선택해주세요."
@@ -159,7 +179,7 @@ extension StaccatoEditorViewModel {
         }
     }
 
-    func modifyStaccato(staccatoId: Int64) async {
+    private func modifyStaccato(staccatoId: Int64) async {
         guard let selectedCategoryId = self.selectedCategory?.categoryId else {
             self.catchError = true
             self.errorMessage = "유효한 카테고리를 선택해주세요."

--- a/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/ViewModel/Staccato/StaccatoEditorViewModel.swift
@@ -52,6 +52,7 @@ final class StaccatoEditorViewModel {
 
     var uploadSuccess = false
     
+    var isSaving = false
     private var lastAPICallTime: Date = .distantPast
     private let throttleInterval: TimeInterval = 2.0
 
@@ -137,6 +138,8 @@ final class StaccatoEditorViewModel {
 extension StaccatoEditorViewModel {
     
     func saveStaccato(_ type: StaccatoEditorMode) async {
+        guard !isSaving else { return }
+        
         let now = Date()
         let timeSinceLastCall = now.timeIntervalSince(lastAPICallTime)
         
@@ -153,6 +156,8 @@ extension StaccatoEditorViewModel {
     }
     
     private func createStaccato() async {
+        isSaving = true
+        
         guard let selectedCategoryId = self.selectedCategory?.categoryId else {
             self.catchError = true
             self.errorMessage = "유효한 카테고리를 선택해주세요."
@@ -177,9 +182,13 @@ extension StaccatoEditorViewModel {
             self.catchError = true
             self.errorMessage = error.localizedDescription
         }
+        
+        isSaving = false
     }
 
     private func modifyStaccato(staccatoId: Int64) async {
+        isSaving = true
+        
         guard let selectedCategoryId = self.selectedCategory?.categoryId else {
             self.catchError = true
             self.errorMessage = "유효한 카테고리를 선택해주세요."
@@ -204,6 +213,8 @@ extension StaccatoEditorViewModel {
             self.catchError = true
             self.errorMessage = error.localizedDescription
         }
+        
+        isSaving = false
     }
 
     func getCategoryCandidates() {


### PR DESCRIPTION
## ⭐️ Issue Number
- #166 

## 🚩 Summary
- 카메라 권한 없는 경우 설정으로 이동하는 Alert 추가 
  (카테고리 생성 수정 뿐만아니라 스타카토 생성 수정, 마이페이지 프로필 모두 적용했습니다.)
- 카테고리 및 스타카토 생성 시 더블 클릭 방지
- 친구 초대창 키보드에 따라 깜빡이는 이슈 수정

## 📸 Screenshots
| 카메라 권한 Alert | 설정으로 이동 |
|:--:|:--:|
|<img width=300 src="https://github.com/user-attachments/assets/ece91c3a-1af4-4fd9-8f0c-3e2d3be5510c">|<img width=300 src="https://github.com/user-attachments/assets/136fbd9a-3be3-45e1-ab0c-b06d698aaae0">|

| 카테고리 저장 버튼 연속 터치 방지 | 스타카토 저장 버튼 연속 터치 방지 |
|:-:|:-:|
|<img width=300 src="https://github.com/user-attachments/assets/8728d426-c316-426f-a033-8272d078d83b">|<img width=300 src="https://github.com/user-attachments/assets/5853b01f-52cf-41b4-b1c3-c1b5156dad9c">|

| 친구 초대창 깜빡임 이슈 해결 |
|:-:|

https://github.com/user-attachments/assets/58fa5c48-1dab-4922-99c9-49c4181a70ed

## 🛠️ Technical Concerns

### Throttle 구현

Combine에 이미 구현되어있는 throttle이 존재하지만 Swift Concurrency를 주로 사용하는 프로젝트 특성에 맞춰 아래와 같이 throttle 기능을 하는 함수를 구현해주었습니다.

```swift
// CategoryEditorViewModel
var isSaving = false
private var lastAPICallTime: Date = .distantPast
private let throttleInterval: TimeInterval = 2.0

func saveCategory(_ type: CategoryEditorType, completion: ((Int64?) -> Void)? = nil) async {
    guard !isSaving else { return }
    
    let now = Date()
    let timeSinceLastCall = now.timeIntervalSince(lastAPICallTime)
    
    guard timeSinceLastCall >= throttleInterval else { return }
    
    lastAPICallTime = now
    
    switch type {
    case .create:
        await completion?(createCategory())
    case .modify:
        await modifyCategory()
    }
}
```

## 📋 To Do

앨범에도 따로 권한 처리가 추가로 안 되어있던 것으로 기억이 되어 한 번 확인해 봐야 할 듯합니다.