### PR TITLE
[Fix/#180] 코멘트 Long Press 제스처 UI 수정

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
@@ -383,13 +383,7 @@ private extension StaccatoDetailView {
         }
 
         var commentView: some View {
-            let corners: UIRectCorner = {
-                if isFromUser {
-                    return [.topLeft, .bottomLeft, .bottomRight]
-                } else {
-                    return [.topRight, .bottomLeft, .bottomRight]
-                }
-            }()
+            let corners: UIRectCorner = [isFromUser ? .topLeft : .topRight, .bottomLeft, .bottomRight]
 
             return Text(comment.content)
                 .typography(.body3)
@@ -414,7 +408,7 @@ private extension StaccatoDetailView {
                         commentView
                             .contextMenu {
                                 // TODO: 댓글 수정 UI 요청
-                                Button {
+                                Button(role: .destructive) {
                                     alertManager.show(
                                         .confirmCancelAlert(
                                             title: "댓글을 삭제하시겠습니까?",
@@ -430,10 +424,8 @@ private extension StaccatoDetailView {
                                             }
                                     )
                                 } label: {
-                                    Text("삭제")
-                                    Image(StaccatoIcon.trash)
+                                    Label("삭제", systemImage: StaccatoIcon.trash.rawValue)
                                 }
-                                .foregroundStyle(.red)
                             }
                     }
                     profileImage

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
@@ -378,22 +378,8 @@ private extension StaccatoDetailView {
         }
 
         var profileImage: some View {
-            if let imageUrl = comment.memberImageUrl {
-                let image = KFImage(URL(string: imageUrl))
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .clipShape(.circle)
-                    .frame(width: 38, height: 38)
-                return AnyView(image)
-            } else {
-                let image = Image(.personCircleFill)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .foregroundStyle(.gray2)
-                    .clipShape(.circle)
-                    .frame(width: 38, height: 38)
-                return AnyView(image)
-            }
+            KFImage(URL(string: comment.memberImageUrl ?? ""))
+                .fillPersonImage(width: 38, height: 38)
         }
 
         var commentView: some View {
@@ -426,6 +412,29 @@ private extension StaccatoDetailView {
                     VStack(alignment: .trailing, spacing: 6) {
                         nicknameText
                         commentView
+                            .contextMenu {
+                                // TODO: 댓글 수정 UI 요청
+                                Button {
+                                    alertManager.show(
+                                        .confirmCancelAlert(
+                                            title: "댓글을 삭제하시겠습니까?",
+                                            message: "삭제하면 되돌릴 수 없어요") {
+                                                Task {
+                                                    do {
+                                                        try await viewModel.deleteComment(comment.commentId)
+                                                        try await viewModel.getComments(staccatoId)
+                                                    } catch {
+                                                        print("❌ Error: \(error.localizedDescription)")
+                                                    }
+                                                }
+                                            }
+                                    )
+                                } label: {
+                                    Text("삭제")
+                                    Image(StaccatoIcon.trash)
+                                }
+                                .foregroundStyle(.red)
+                            }
                     }
                     profileImage
                 }
@@ -441,35 +450,6 @@ private extension StaccatoDetailView {
                 }
                 .padding(.trailing, 24)
             }
-        }
-        .contextMenu {
-//            Button {
-//                // TODO: 댓글 수정 UI 요청
-//            } label: {
-//                Text("수정")
-//                Image(StaccatoIcon.pencilLine)
-//            }
-            
-            Button {
-                alertManager.show(
-                    .confirmCancelAlert(
-                        title: "댓글을 삭제하시겠습니까?",
-                        message: "삭제하면 되돌릴 수 없어요") {
-                            Task {
-                                do {
-                                    try await viewModel.deleteComment(comment.commentId)
-                                    try await viewModel.getComments(staccatoId)
-                                } catch {
-                                    print("❌ Error: \(error.localizedDescription)")
-                                }
-                            }
-                        }
-                )
-            } label: {
-                Text("삭제")
-                Image(StaccatoIcon.trash)
-            }
-            .foregroundStyle(.red)
         }
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/ViewModel/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/ViewModel/StaccatoDetailViewModel.swift
@@ -8,15 +8,13 @@
 import Foundation
 
 @MainActor
-class StaccatoDetailViewModel: ObservableObject {
+final class StaccatoDetailViewModel: ObservableObject {
 
     // MARK: - Properties
 
     @Published var staccatoDetail: StaccatoDetailModel?
     @Published var selectedFeeling: FeelingType?
     @Published var comments: [CommentModel] = []
-    @Published var shouldScrollToBottom: Bool = false
-
     @Published var shareLink: URL?
 
     let userId: Int64 = AuthTokenManager.shared.getUserId() ?? -1


### PR DESCRIPTION
## ⭐️ Issue Number
- #180 

## 🚩 Summary
- 코멘트 Long Press 제스처 UI 수정
- 남의 코멘트 Long Press 못하도록 수정
- ViewModel에 final 키워드 붙이기

## 📸 Screenshots
| 코멘트 Long Press 제스처 UI 수정 |
|:-:|

https://github.com/user-attachments/assets/eeb954a1-e1e7-48cc-91d3-87696406000c


## 📋 To Do

- 뭔가뭔가.. 코멘트 작성하는 곳에 Focus가 되었을때, 화면의 움직임 및 스크롤 되는 위치가 불안정한 것 같아서 이걸 한 번 손봐야할 것 같습니다.. 
  (~~시도했다가 실패한것은 안비밀... 흑흑~~)

