### PR TITLE
[Fix/#189] 스타카토에서 다른 스타카토로 네비게이션 안 되는 문제 해결

### DIFF
--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
@@ -63,6 +63,7 @@ struct CategoryListView: View {
                     switch destination {
                     case .staccatoDetail(let staccatoId):
                         StaccatoDetailView(staccatoId)
+                            .id(staccatoId)
                             .environmentObject(detentManager)
                     case .categoryDetail(let categoryId):
                         CategoryDetailView(categoryId, viewModel)

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/ViewModel/StaccatoDetailViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/ViewModel/StaccatoDetailViewModel.swift
@@ -18,7 +18,7 @@ final class StaccatoDetailViewModel: ObservableObject {
     @Published var shareLink: URL?
 
     let userId: Int64 = AuthTokenManager.shared.getUserId() ?? -1
-    
+
 }
 
 


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #189 

## 🚩 Summary
스타카토에서 다른 스타카토가 push 될 때, NavigationManager는 기존 뷰를 remove하고 새로운 뷰를 append합니다.
하지만 이 속도가 빨라서 SwiftUI가 뷰를 재사용하게 되고, 새로운 데이터를 fetch하지 않았기 때문에 네비게이션이 안 된 것처럼 보인 것 같습니다.
이에, View에 id를 심어줌으로써, staccatoId가 변하면 새로운 뷰로 인식하여 뷰를 새로 그리고 데이터를 fetch하도록 했습니다.

## 📸 Screenshots

https://github.com/user-attachments/assets/15a588f6-2a46-4c23-ae4a-48bd6f5ac02b

