### PR TITLE
[Fix/#196] 스타카토 생성 시, 카테고리 선택 안 되는 문제 해결하여 2.1.2 릴리즈

### DIFF
--- a/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
+++ b/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
@@ -356,7 +356,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 250710.1;
+				CURRENT_PROJECT_VERSION = 250711.1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L995XJC5CV;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamstaccato.staccato-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -408,7 +408,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 250710.1;
+				CURRENT_PROJECT_VERSION = 250711.1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L995XJC5CV;
 				ENABLE_PREVIEWS = YES;
@@ -431,7 +431,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamstaccato.staccato-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/SelectCategoryView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/SelectCategoryView.swift
@@ -32,6 +32,7 @@ struct SelectCategoryView: View {
             }
         }
         .onAppear {
+            if selectedCategory == nil { selectedCategory = categories.first }
             category = selectedCategory
         }
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #196 

## 🚩 Summary
- 스타카토 생성 시, 카테고리 선택 안 되는 문제 해결했습니다.
- 급하게 패치되어야 하는 문제라 생각하여 바로 2.1.2 로 릴리즈했습니다.