### PR TITLE
[Fix/#198] 홈 - 카테고리리스트 및 마커 업데이트 안 되는 문제 해결

### DIFF
--- a/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
+++ b/Staccato-iOS/Staccato-iOS.xcodeproj/project.pbxproj
@@ -356,7 +356,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 250711.1;
+				CURRENT_PROJECT_VERSION = 250715.1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L995XJC5CV;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamstaccato.staccato-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -408,7 +408,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 250711.1;
+				CURRENT_PROJECT_VERSION = 250715.1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L995XJC5CV;
 				ENABLE_PREVIEWS = YES;
@@ -431,7 +431,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamstaccato.staccato-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
@@ -57,8 +57,9 @@ struct CategoryListView: View {
                 }
 
                 .onAppear {
-                    detentManager.updateDetent(geometry.size.height)
+                    fetchCategoryList()
                 }
+
                 .navigationDestination(for: NavigationDestination.self) { destination in
                     switch destination {
                     case .staccatoDetail(let staccatoId):
@@ -71,9 +72,6 @@ struct CategoryListView: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            fetchCategoryList()
         }
 
         .onChange(of: viewModel.filterSelection) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/ViewModel/CategoryEditorViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/ViewModel/CategoryEditorViewModel.swift
@@ -184,7 +184,6 @@ final class CategoryEditorViewModel {
 
         do {
             let response = try await STService.shared.categoryService.postCategory(body)
-            try await categoryViewModel.getCategoryList()
             self.uploadSuccess = true
             isSaving = false
             return response.categoryId
@@ -216,7 +215,6 @@ final class CategoryEditorViewModel {
         do {
             try await STService.shared.categoryService.putCategory(id: id, query)
             self.uploadSuccess = true
-            try await categoryViewModel.getCategoryList()
             await categoryViewModel.getCategoryDetail(id)
         } catch {
             errorMessage = error.localizedDescription

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/ViewModel/CategoryViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/ViewModel/CategoryViewModel.swift
@@ -66,8 +66,6 @@ final class CategoryViewModel: ObservableObject {
             case .member:
                 try await STService.shared.categoryService.deleteCategoryFromMe(categoryDetail.categoryId)
             }
-            
-            try await getCategoryList()
             return true
         } catch {
             print("⚠️ \(error.localizedDescription) - delete category")


### PR DESCRIPTION
## ⭐️ Issue Number
- Resolved #198 

## 🚩 Summary
- **카테고리 리스트 업데이트**
  카테고리 리스트는 스타카토 생성/수정/삭제, 카테고리 생성/수정/삭제, 초대 수락 이후에 모두 업데이트되어야합니다.
그러나 `getCategoryList` 메소드는 `CategoryViewModel`에 구현되어있기 때문에 모든 상황마다 해당 메소드를 호출하는 게 쉽지 않습니다.
기존 코드에서 누락되어있는 경우가 꽤 있기도 했고요(발견한 건 초대 수락, 스타카토 삭제입니다)

  (기존)카테고리 리스트가 업데이트되어야 하는 상황을 일일이 체크하기보다는, 
  (수정후)홈이 onAppear될 때마다 새롭게 리스트를 갱신하는 편이 더 안전하겠다고 판단하여 수정했습니다.

- **마커 업데이트**
  클러스터링을 구현하면서 마커의 타입이 바뀌었는데, 
마커를 업데이트하는 메소드에 반영이 안 되어 발생한 문제였습니다. 수정 완료했습니다.

## 📸 Screenshots
| 스타카토 삭제 후 리스트 업데이트 | 스타카토 생성 후 리스트 업데이트 | 마커 색상 변경 | 마커 위치 변경 |
|:--:|:--:|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/aa6f6db0-c368-4dd4-af76-9c463d6a07c9" width="200"> | <img src="https://github.com/user-attachments/assets/7c4ad73d-bc89-487e-a32f-84b44217ea65" width="200"> |<img src="https://github.com/user-attachments/assets/8bf4da30-7351-43c9-bf1f-0e1e7621cf53" width ="200">| <img src="https://github.com/user-attachments/assets/ebd713d3-ee54-4094-88b9-1d9e57699ca5" width="200">|

## Testflight
`2.1.3 (250415.1)`