### PR TITLE
[Fix/#193] Push 알림 서버 token deviceid 수정

### DIFF
--- a/Staccato-iOS/Staccato-iOS/App/AppDelegate.swift
+++ b/Staccato-iOS/Staccato-iOS/App/AppDelegate.swift
@@ -9,6 +9,7 @@ import GoogleMaps
 import GooglePlacesSwift
 import FirebaseCore
 import FirebaseMessaging
+import FirebaseInstallations
 import UIKit
 
 // Maps SDK 초기화를 위해 AppDelegate 구현
@@ -45,8 +46,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
             if let error {
                 print("FCM 토큰 가져오기 실패: \(error)")
             } else if let token {
-                let deviceID = UIDevice.current.identifierForVendor!.uuidString
-                Task { try await NotificationService.postNotificationToken(token, deviceID) }
+                Task {
+                    let deviceID = try await Installations.installations().installationID()
+                    try await NotificationService.postNotificationToken(token, deviceID)
+                }
             }
         }
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- #193 

## 🚩 Summary
- 서버에 보내는 Push 알림 등록 API `deviceId`를 APNs -> FID로 수정했습니다.
-  서버에서 동일한 FCM Token에 대한 중복처리를 해주셔서 FID 수정 외 코드는 없습니다.

