### PR TITLE
[Feat/#192] Push 알림 화면 이동 구현

### DIFF
--- a/Staccato-iOS/Staccato-iOS/App/AppDelegate.swift
+++ b/Staccato-iOS/Staccato-iOS/App/AppDelegate.swift
@@ -11,8 +11,8 @@ import FirebaseCore
 import FirebaseMessaging
 import UIKit
 
-// Maps SDK 초기화를 위해 AppDelegate 구현
-final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
+// Maps SDK 초기화 및 FCM을 위해 AppDelegate 구현
+final class AppDelegate: NSObject, UIApplicationDelegate {
     
     func application(
         _ application: UIApplication,
@@ -30,6 +30,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
         // 알림 센터 델리게이트 설정
         UNUserNotificationCenter.current().delegate = self
         
+        NotificationCenter.default.addObserver(
+            forName: .pushNotificationReceived,
+            object: nil,
+            queue: .main
+        ) { notification in
+            PushNotificationManager.shared.handlePushNotification(notification)
+        }
+        
         return true
     }
     
@@ -39,7 +47,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
     ) {
         Messaging.messaging().apnsToken = deviceToken
     }
-    
+}
+
+// MARK: - MessagingDelegate
+
+extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         Messaging.messaging().token { token, error in
             if let error {
@@ -52,12 +64,32 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate {
     }
 }
 
+// MARK: - UNUserNotificationCenterDelegate
+
 extension AppDelegate: UNUserNotificationCenterDelegate {
+    
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         completionHandler([.banner, .sound, .badge])
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        
+        let userInfo = response.notification.request.content.userInfo
+        
+        NotificationCenter.default.post(
+            name: .pushNotificationReceived,
+            object: nil,
+            userInfo: userInfo as? [String: Any] ?? [:]
+        )
+        
+        completionHandler()
     }
 }

--- a/Staccato-iOS/Staccato-iOS/Model/PushNotification/PushNotificationType.swift
+++ b/Staccato-iOS/Staccato-iOS/Model/PushNotification/PushNotificationType.swift
@@ -1,0 +1,15 @@
+//
+//  PushNotificationType.swift
+//  Staccato-iOS
+//
+//  Created by 김영현 on 7/15/25.
+//
+
+import Foundation
+
+enum PushNotificationType: String {
+    case receiveInvitation = "RECEIVE_INVITATION"
+    case acceptInvitation = "ACCEPT_INVITATION"
+    case createStaccato = "STACCATO_CREATED"
+    case createComment = "COMMENT_CREATED"
+}

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryDetailView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 struct CategoryDetailView: View {
     
     @Environment(NavigationManager.self) var navigationManager
-    @EnvironmentObject var detentManager: BottomSheetDetentManager
+    @StateObject private var detentManager = BottomSheetDetentManager.shared
     @EnvironmentObject var homeViewModel: HomeViewModel
     
     private let categoryId: Int64

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryDetailView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 struct CategoryDetailView: View {
     
     @Environment(NavigationManager.self) var navigationManager
-    @StateObject private var detentManager = BottomSheetDetentManager.shared
+    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     @EnvironmentObject var homeViewModel: HomeViewModel
     
     private let categoryId: Int64

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryEditorView.swift
@@ -121,6 +121,10 @@ struct CategoryEditorView: View {
                 dismiss()
             }
         }
+        
+        .onReceive(NotificationCenter.default.publisher(for: .pushNotificationReceived)) { _ in
+            dismiss()
+        }
     }
 }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct CategoryListView: View {
 
     @Environment(NavigationManager.self) var navigationManager
-    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     @EnvironmentObject var mypageViewModel: MyPageViewModel
     @Bindable var bindableNavigationManager: NavigationManager
+    @StateObject private var detentManager = BottomSheetDetentManager.shared
     
     @StateObject private var viewModel = CategoryViewModel()
     @State private var selectedCategory: CategoryModel?
@@ -64,10 +64,8 @@ struct CategoryListView: View {
                     case .staccatoDetail(let staccatoId):
                         StaccatoDetailView(staccatoId)
                             .id(staccatoId)
-                            .environmentObject(detentManager)
                     case .categoryDetail(let categoryId):
                         CategoryDetailView(categoryId, viewModel)
-                            .environmentObject(detentManager)
                     }
                 }
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Category/View/CategoryListView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct CategoryListView: View {
 
     @Environment(NavigationManager.self) var navigationManager
+    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     @EnvironmentObject var mypageViewModel: MyPageViewModel
     @Bindable var bindableNavigationManager: NavigationManager
-    @StateObject private var detentManager = BottomSheetDetentManager.shared
     
     @StateObject private var viewModel = CategoryViewModel()
     @State private var selectedCategory: CategoryModel?
@@ -64,8 +64,10 @@ struct CategoryListView: View {
                     case .staccatoDetail(let staccatoId):
                         StaccatoDetailView(staccatoId)
                             .id(staccatoId)
+                            .environmentObject(detentManager)
                     case .categoryDetail(let categoryId):
                         CategoryDetailView(categoryId, viewModel)
+                            .environmentObject(detentManager)
                     }
                 }
             }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/GMSMapViewRepresentable.swift
@@ -13,9 +13,9 @@ import SwiftUI
 struct GMSMapViewRepresentable: UIViewRepresentable {
 
     @EnvironmentObject var viewModel: HomeViewModel
-    @EnvironmentObject var detentManager: BottomSheetDetentManager
     @Environment(NavigationManager.self) var navigationManager
 
+    @StateObject private var detentManager = BottomSheetDetentManager.shared
     private let mapView = GMSMapView()
 
     func makeUIView(context: Context) -> GMSMapView {

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/GMSMapViewRepresentable.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/GMSMapViewRepresentable.swift
@@ -13,9 +13,9 @@ import SwiftUI
 struct GMSMapViewRepresentable: UIViewRepresentable {
 
     @EnvironmentObject var viewModel: HomeViewModel
+    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     @Environment(NavigationManager.self) var navigationManager
-
-    @StateObject private var detentManager = BottomSheetDetentManager.shared
+    
     private let mapView = GMSMapView()
 
     func makeUIView(context: Context) -> GMSMapView {

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
@@ -17,10 +17,10 @@ struct HomeView: View {
     //NOTE: View, ViewModel
     @EnvironmentObject private var viewModel: HomeViewModel
     @EnvironmentObject private var mypageViewModel: MyPageViewModel
+    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     private let mapView = GMSMapViewRepresentable()
 
     // NOTE: Managers
-    @StateObject private var detentManager = BottomSheetDetentManager.shared
     @Environment(NavigationManager.self) private var navigationManager
     @State private var alertManager = StaccatoAlertManager()
     @State private var locationAuthorizationManager = STLocationManager.shared
@@ -43,6 +43,7 @@ struct HomeView: View {
             ZStack(alignment: .topLeading) {
                 mapView
                     .ignoresSafeArea(.all)
+                    .environmentObject(detentManager)
                 
                 myPageButton
                     .padding(10)
@@ -82,6 +83,7 @@ struct HomeView: View {
         }
         .sheet(isPresented: $detentManager.isbottomSheetPresented) {
             CategoryListView(navigationManager)
+                .environmentObject(detentManager)
                 .interactiveDismissDisabled(true)
                 .presentationContentInteraction(.scrolls)
                 .presentationBackgroundInteraction(.enabled)

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
@@ -20,7 +20,7 @@ struct HomeView: View {
     private let mapView = GMSMapViewRepresentable()
 
     // NOTE: Managers
-    @EnvironmentObject private var detentManager: BottomSheetDetentManager
+    @StateObject private var detentManager = BottomSheetDetentManager.shared
     @Environment(NavigationManager.self) private var navigationManager
     @State private var alertManager = StaccatoAlertManager()
     @State private var locationAuthorizationManager = STLocationManager.shared
@@ -43,7 +43,6 @@ struct HomeView: View {
             ZStack(alignment: .topLeading) {
                 mapView
                     .ignoresSafeArea(.all)
-                    .environmentObject(detentManager)
                 
                 myPageButton
                     .padding(10)
@@ -83,7 +82,6 @@ struct HomeView: View {
         }
         .sheet(isPresented: $detentManager.isbottomSheetPresented) {
             CategoryListView(navigationManager)
-                .environmentObject(detentManager)
                 .interactiveDismissDisabled(true)
                 .presentationContentInteraction(.scrolls)
                 .presentationBackgroundInteraction(.enabled)
@@ -91,7 +89,6 @@ struct HomeView: View {
                     Set(BottomSheetDetent.allCases.map { $0.detent }),
                     selection: $detentManager.selectedDetent
                 )
-
                 .fullScreenCover(isPresented: $viewModel.isStaccatoListPresented) {
                     StaccatoListView(staccatos: viewModel.staccatoClusterList)
                 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
@@ -21,8 +21,8 @@ struct HomeView: View {
     private let mapView = GMSMapViewRepresentable()
 
     // NOTE: Managers
-    @StateObject private var pushNotificationManager = PushNotificationManager.shared
     @Environment(NavigationManager.self) private var navigationManager
+    @StateObject private var pushNotificationManager = PushNotificationManager.shared
     @State private var alertManager = StaccatoAlertManager()
     @State private var locationAuthorizationManager = STLocationManager.shared
 
@@ -100,6 +100,19 @@ struct HomeView: View {
                         .onDisappear {
                             detentManager.isbottomSheetPresented = true
                         }
+                }
+                .onChange(of: pushNotificationManager.moveToCategory) { _, categoryId in
+                    if categoryId != 0 {
+                        navigationManager.navigate(to: .categoryDetail(categoryId))
+                        pushNotificationManager.moveToCategory = 0
+                    }
+                }
+                
+                .onChange(of: pushNotificationManager.moveToStaccato) { _, staccatoId in
+                    if staccatoId != 0 {
+                        navigationManager.navigate(to: .staccatoDetail(staccatoId))
+                        pushNotificationManager.moveToStaccato = 0
+                    }
                 }
         }
         .fullScreenCover(isPresented: $isMyPagePresented) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Home/View/HomeView.swift
@@ -21,6 +21,7 @@ struct HomeView: View {
     private let mapView = GMSMapViewRepresentable()
 
     // NOTE: Managers
+    @StateObject private var pushNotificationManager = PushNotificationManager.shared
     @Environment(NavigationManager.self) private var navigationManager
     @State private var alertManager = StaccatoAlertManager()
     @State private var locationAuthorizationManager = STLocationManager.shared
@@ -93,6 +94,12 @@ struct HomeView: View {
                 )
                 .fullScreenCover(isPresented: $viewModel.isStaccatoListPresented) {
                     StaccatoListView(staccatos: viewModel.staccatoClusterList)
+                }
+                .fullScreenCover(isPresented: $pushNotificationManager.shouldShowInvitation) {
+                    CategoryInvitationManagingView()
+                        .onDisappear {
+                            detentManager.isbottomSheetPresented = true
+                        }
                 }
         }
         .fullScreenCover(isPresented: $isMyPagePresented) {

--- a/Staccato-iOS/Staccato-iOS/Presentation/MyPage/View/CategoryInvitationManagerView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/MyPage/View/CategoryInvitationManagerView.swift
@@ -45,6 +45,11 @@ struct CategoryInvitationManagingView: View {
             viewModel.fetchReceivedInvitations()
             viewModel.fetchSentInvitations()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .pushNotificationReceived)) { notification in
+            if PushNotificationManager.shared.type != .receiveInvitation {
+                dismiss()
+            }
+        }
     }
 }
 

--- a/Staccato-iOS/Staccato-iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/MyPage/View/MyPageView.swift
@@ -11,6 +11,7 @@ import Kingfisher
 
 struct MyPageView: View {
     
+    @Environment(\.dismiss) var dismiss
     @Environment(\.openURL) var openURL
     @Environment(NavigationManager.self) var navigationManager
     @EnvironmentObject private var viewModel: MyPageViewModel
@@ -126,6 +127,10 @@ extension MyPageView {
         
         .onChange(of: photoItem) { _, newValue in
             loadTransferable(from: newValue)
+        }
+        
+        .onReceive(NotificationCenter.default.publisher(for: .pushNotificationReceived)) { _ in
+            dismiss()
         }
     }
     

--- a/Staccato-iOS/Staccato-iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class SignInViewModel: ObservableObject {
+final class SignInViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false
     @Published var isValid: Bool = true
 }

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
@@ -15,8 +15,8 @@ struct StaccatoDetailView: View {
     // MARK: - State Properties
     
     let staccatoId: Int64
-    @StateObject private var detentManager = BottomSheetDetentManager.shared
     @Environment(NavigationManager.self) var navigationManager
+    @EnvironmentObject private var detentManager: BottomSheetDetentManager
     @EnvironmentObject var homeViewModel: HomeViewModel
     @StateObject private var viewModel = StaccatoDetailViewModel()
     

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoDetailView.swift
@@ -15,9 +15,9 @@ struct StaccatoDetailView: View {
     // MARK: - State Properties
     
     let staccatoId: Int64
+    @StateObject private var detentManager = BottomSheetDetentManager.shared
     @Environment(NavigationManager.self) var navigationManager
     @EnvironmentObject var homeViewModel: HomeViewModel
-    @EnvironmentObject var detentManager: BottomSheetDetentManager
     @StateObject private var viewModel = StaccatoDetailViewModel()
     
     @State private var alertManager = StaccatoAlertManager()

--- a/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoEditorView.swift
+++ b/Staccato-iOS/Staccato-iOS/Presentation/Staccato/View/StaccatoEditorView.swift
@@ -122,6 +122,10 @@ struct StaccatoEditorView: View {
         } message: {
             Text("Staccato 사용을 위해 설정에서 위치 접근 권한을 허용해주세요.")
         }
+        
+        .onReceive(NotificationCenter.default.publisher(for: .pushNotificationReceived)) { _ in
+            dismiss()
+        }
     }
 }
 

--- a/Staccato-iOS/Staccato-iOS/Util/Extension/Ex+Notification.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Extension/Ex+Notification.swift
@@ -1,0 +1,12 @@
+//
+//  Ex+Notification.swift
+//  Staccato-iOS
+//
+//  Created by 김영현 on 7/6/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let pushNotificationReceived = Notification.Name("pushNotificationReceived")
+}

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
@@ -26,14 +26,11 @@ enum BottomSheetDetent: CaseIterable {
 
 @MainActor
 final class BottomSheetDetentManager: ObservableObject {
-    static let shared = BottomSheetDetentManager()
     
     var previousDetent: BottomSheetDetent = .medium
     @Published var currentDetent: BottomSheetDetent = .medium
     @Published var selectedDetent: PresentationDetent = BottomSheetDetent.medium.detent
     @Published var isbottomSheetPresented: Bool = false
-    
-    private init() {}
     
     func updateDetent(_ newHeight: CGFloat) {
         if let detectedDetent = detectDetent(from: newHeight) {

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/BottomSheetDetentManager.swift
@@ -26,11 +26,14 @@ enum BottomSheetDetent: CaseIterable {
 
 @MainActor
 final class BottomSheetDetentManager: ObservableObject {
-
-    @Published var currentDetent: BottomSheetDetent = .medium
+    static let shared = BottomSheetDetentManager()
+    
     var previousDetent: BottomSheetDetent = .medium
-    @Published var isbottomSheetPresented: Bool = true
+    @Published var currentDetent: BottomSheetDetent = .medium
     @Published var selectedDetent: PresentationDetent = BottomSheetDetent.medium.detent
+    @Published var isbottomSheetPresented: Bool = false
+    
+    private init() {}
     
     func updateDetent(_ newHeight: CGFloat) {
         if let detectedDetent = detectDetent(from: newHeight) {

--- a/Staccato-iOS/Staccato-iOS/Util/Manager/PushNotificationManager.swift
+++ b/Staccato-iOS/Staccato-iOS/Util/Manager/PushNotificationManager.swift
@@ -1,0 +1,46 @@
+//
+//  PushNotificationManager.swift
+//  Staccato-iOS
+//
+//  Created by 김영현 on 7/6/25.
+//
+
+import Foundation
+
+final class PushNotificationManager: ObservableObject {
+    static let shared = PushNotificationManager()
+    
+    @Published var shouldShowInvitation: Bool = false
+    
+    private init() {}
+    
+    func handlePushNotification(_ notification: Notification) {
+        guard let userInfo = notification.userInfo as? [String: Any] else { return }
+        
+        if let type = userInfo["type"] as? String {
+            switch type {
+            case "RECEIVE_INVITATION":
+                // 딜레이를 두고 실행하여 UI가 안정화된 후 처리
+                Task {
+                    try await Task.sleep(for: .seconds(1))
+                    await MainActor.run {
+                        shouldShowInvitation = true
+                    }
+                }
+            case "ACCEPT_INVITATION":
+                if let categoryId = userInfo["categoryId"] as? String {
+                    // 나중에 구현
+                    break
+                }
+            case "STACCATO_CREATED", "COMMENT_CREATED":
+                if let staccatoId = userInfo["staccatoId"] as? String {
+                    // 나중에 구현
+                    break
+                }
+            default:
+                break
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #192 

## 🚩 Summary
- Push 알림 화면 이동 구현

## 📸 Screenshots
| 초대받은 경우 | 공통 카테고리에 새로운 멤버가 들어은 경우 |
|:--:|:--:|
|<img width=300 src="https://github.com/user-attachments/assets/82d3eb79-3af6-43ee-a783-0baf202acf8d">|<img width=300 src="https://github.com/user-attachments/assets/bfcaca40-1727-4743-94cd-b29ac05cf002">|
| 새로운 스타카토 생성된 경우 | 새로운 댓글이 달린 경우 |
|<img width=300 src="https://github.com/user-attachments/assets/691f35e9-b2cf-4fee-9a16-198fedbcbca2">|<img width=300 src="https://github.com/user-attachments/assets/8d530c2b-2401-48a6-be83-da0d446ab5fc">|

## 🛠️ Technical Concerns

### 알림 처리

Push 알림이 왔을때, 사용자가 해당 알림을 클릭하면 실행되는 함수는 아래 함수이다.

```swift
func userNotificationCenter(
    _ center: UNUserNotificationCenter,
    didReceive response: UNNotificationResponse,
    withCompletionHandler completionHandler: @escaping () -> Void
)
```
해당 함수는 앱의 상태(foreground, background, suspend)와 상관없이 알림을 클릭하면 호출된다.
이때, 앱이 실행되고 있지 않은 상태는 상관없지만, 사용자가 특정 화면에 있는 경우 화면 이동을 어떻게 해야할지에 대한 고민이 있었다.

bottomSheet 내부에서 처리되는 화면이 아닌 fullScreen으로 띄워지는 각종 수정/생성, 마이페이지가 문제였다.
bottomSheet의 경우는 기존의 `NavigationState`를 활용해 원하는 스타카토, 카테고리로 이동하거나 초대 페이지를 띄우기만 하면 되는데, fullScreen으로 띄워지는 화면에 존재하는 경우 다른 화면으로 이동하기가 번거로웠다.

Android의 경우 사용자가 foreground 상태에서 어떤 화면에 있던 해당 화면은 pop 되고 이동해야하는 화면으로 이동하도록 구현되었다고 들어 일단은 fullScreen 모달로 띄워지는 화면의 경우 알림을 클릭할 경우 `dismiss`되고 원하는 화면으로 이동되도록 구현했다.

하지만 이럴 경우 사용자가 카테고리 혹은 스타카토를 수정, 생성하는 화면에 있다가 알림이 클릭되면 작성하던 화면이 없어지는 것이라 사용자 경험을 저하시킬 수 있다는 우려가 있다.

추후 조금 더 개선해야할 상황..😇

추가로 이번 기능을 구현하며 flow가 조금만 복잡해져도 화면 전환이 어려워지는 것을 느꼈고, Coordinator 패턴의 도입도 좋을 것 같다는 생각이 들었다.
